### PR TITLE
Bind a plugin action or pane to a key from the pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,43 @@ description someone had to remember to write:
  bind one to a key:  [[keys.command]] type = "plugin_action" command = "…"
 ```
 
-Enter runs the highlighted action, so you can try something without first working out how to
-reach it. The last line is the config snippet for binding it to a key.
+Enter runs the highlighted entry — an action, or a pane it opens — so you can try something
+without first working out how to reach it.
+
+### Binding it to a key
+
+herdr has no command palette, and a plugin manifest cannot suggest a keybinding. Until an
+action is written into `config.toml` by hand there is no way to reach it, and nothing tells
+you it exists in the first place.
+
+Press `b`, then a letter: the entry gets bound to `prefix+shift+<letter>`. Shift is not
+optional — herdr's own defaults live on `prefix+<letter>` and are not exposed by the CLI, so
+staying out of that range is the only way to be sure nothing is shadowed.
+
+Panes can be bound too. herdr has a binding type for actions (`plugin_action`) but none for
+opening a pane, so those are written as `type = "shell"` running `herdr plugin pane open`.
+This matters more than it sounds: several plugins expose only a pane, and without it `b`
+would do nothing for them.
+
+Before writing anything, the pane shows the exact lines and the file they go into:
+
+```
+ This appends to /Users/you/.config/herdr/config.toml:
+
+   # added by herdr-lazy
+   [[keys.command]]
+   key = "prefix+shift+z"
+   type = "shell"
+   command = "herdr plugin pane open --plugin triage --entrypoint list"
+
+ [y] write it   [n / esc] cancel
+```
+
+That confirmation is not a formality. The pane is launched by herdr, so an environment
+variable set in your shell never reaches it — there is no way to point this at a scratch file
+and try it safely. Your config is copied to `config.toml.herdr-lazy-backup` before the first
+write, every added block is marked `# added by herdr-lazy`, and a key that is already bound
+is refused rather than shadowed.
 
 ## Acting on several at once
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1010,6 +1010,177 @@ pub(crate) fn is_self_id(plugin_id: &str) -> bool {
     plugin_id == PLUGIN_ID
 }
 
+/// herdr's config.toml.
+///
+/// Derived from `HERDR_SOCKET_PATH` (herdr sets it for every plugin, and the socket lives in
+/// the config directory) rather than assuming `~/.config/herdr` — a user with XDG_CONFIG_HOME
+/// set elsewhere would otherwise get a second config file that herdr never reads.
+pub(crate) fn herdr_config_path() -> Option<PathBuf> {
+    // Overridable so the write path can be exercised against a throwaway file. Without it the
+    // only way to test binding is to point HERDR_SOCKET_PATH somewhere else, which also cuts
+    // the CLI off from the running server — so the pane has nothing to bind.
+    if let Ok(p) = env::var("HERDR_LAZY_CONFIG_PATH") {
+        return Some(PathBuf::from(p));
+    }
+    let sock = env::var("HERDR_SOCKET_PATH").ok()?;
+    let dir = PathBuf::from(sock).parent()?.to_path_buf();
+    Some(dir.join("config.toml"))
+}
+
+/// Keys already bound in config.toml, as written.
+///
+/// A deliberately shallow read: find `key = "…"` lines. Parsing TOML properly would mean a
+/// dependency, and this only has to answer "is this string already spoken for" — a question
+/// where a false positive (refusing to bind) is harmless and a false negative would silently
+/// shadow an existing binding.
+fn bound_keys(config: &str) -> Vec<String> {
+    config
+        .lines()
+        .filter_map(|l| {
+            let l = l.trim();
+            if l.starts_with('#') || !l.starts_with("key") {
+                return None;
+            }
+            let (_, rest) = l.split_once('=')?;
+            let rest = rest.trim();
+            rest.strip_prefix('"')?
+                .split('"')
+                .next()
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+/// Would this key collide with something already bound?
+///
+/// Separate from `bind_action` so the pane can check before showing a confirmation screen —
+/// asking someone to confirm a write that is going to be refused is a waste of their time.
+pub(crate) fn check_bind_conflict(key: &str) -> Result<(), String> {
+    let Some(path) = herdr_config_path() else {
+        return Err("cannot locate herdr's config.toml (no HERDR_SOCKET_PATH)".to_string());
+    };
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    if bound_keys(&existing).iter().any(|k| k == key) {
+        return Err(format!(
+            "{} is already bound in config.toml — pick another, or edit it by hand",
+            key
+        ));
+    }
+    Ok(())
+}
+
+/// Append a `[[keys.command]]` binding for a plugin action.
+///
+/// Writing to someone's herdr config is the most invasive thing herdr-lazy does, so: refuse
+/// on a conflict rather than shadowing, back the file up first, and mark what was added so it
+/// can be found and removed by hand later.
+/// What a binding will invoke.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BindTarget {
+    /// A declared action: herdr has a first-class binding type for these.
+    Action(String),
+    /// A pane. herdr's `[[keys.command]]` has no type for opening one, so this binds the CLI
+    /// command instead, as `type = "shell"`. Without this, the four plugins in the default
+    /// set that expose only panes could not be bound at all.
+    Pane(String),
+}
+
+impl BindTarget {
+    /// The `type` and `command` fields for this target.
+    pub(crate) fn toml_fields(&self, plugin_id: &str) -> (String, String) {
+        match self {
+            BindTarget::Action(id) => {
+                ("plugin_action".to_string(), format!("{}.{}", plugin_id, id))
+            }
+            BindTarget::Pane(id) => (
+                "shell".to_string(),
+                format!(
+                    "herdr plugin pane open --plugin {} --entrypoint {}",
+                    plugin_id, id
+                ),
+            ),
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        match self {
+            BindTarget::Action(id) | BindTarget::Pane(id) => id,
+        }
+    }
+}
+
+pub(crate) fn bind_action(
+    plugin_id: &str,
+    target: &BindTarget,
+    key: &str,
+) -> Result<String, String> {
+    let Some(path) = herdr_config_path() else {
+        return Err("cannot locate herdr's config.toml (no HERDR_SOCKET_PATH)".to_string());
+    };
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+
+    if bound_keys(&existing).iter().any(|k| k == key) {
+        return Err(format!(
+            "{} is already bound in config.toml — pick another, or edit it by hand",
+            key
+        ));
+    }
+
+    // Back up before touching it. Same name every time: one restore point is what someone
+    // needs after a mistake, and a directory of timestamped copies is its own mess.
+    if !existing.is_empty() {
+        let _ = fs::write(path.with_extension("toml.herdr-lazy-backup"), &existing);
+    }
+
+    let (kind, command) = target.toml_fields(plugin_id);
+    let mut body = existing;
+    if !body.is_empty() && !body.ends_with('\n') {
+        body.push('\n');
+    }
+    body.push_str(&format!(
+        "\n# added by herdr-lazy\n[[keys.command]]\nkey = \"{}\"\ntype = \"{}\"\ncommand = \"{}\"\n",
+        key, kind, command
+    ));
+    fs::write(&path, body).map_err(|e| format!("could not write config.toml: {}", e))?;
+
+    // Ask herdr to pick it up; without this the binding does nothing until the next restart.
+    let reloaded = matches!(run_herdr(&["server", "reload-config"]), Ok((true, _, _)));
+    Ok(if reloaded {
+        format!("bound {} to {}.{}", key, plugin_id, target.id())
+    } else {
+        format!(
+            "wrote {} to config.toml — run `herdr server reload-config` to activate",
+            key
+        )
+    })
+}
+
+/// The `type` and `command` a binding would use — so the confirmation screen can show the
+/// exact lines that will be written rather than a paraphrase of them.
+pub(crate) fn bind_toml_fields(target: &BindTarget, plugin_id: &str) -> (String, String) {
+    target.toml_fields(plugin_id)
+}
+
+/// Open one of a plugin's panes.
+pub(crate) fn open_pane(plugin_id: &str, entrypoint: &str) -> String {
+    match run_herdr(&[
+        "plugin",
+        "pane",
+        "open",
+        "--plugin",
+        plugin_id,
+        "--entrypoint",
+        entrypoint,
+    ]) {
+        Ok((true, _, _)) => format!("opened {} ({})", entrypoint, plugin_id),
+        Ok((false, out, err)) => {
+            let msg = if err.trim().is_empty() { out } else { err };
+            format!("could not open {}: {}", entrypoint, msg.trim())
+        }
+        Err(e) => format!("could not run herdr: {}", e),
+    }
+}
+
 /// Run one of a plugin's declared actions.
 ///
 /// The details view lists what a plugin can do; without this it could only describe them,
@@ -1661,6 +1832,85 @@ mod tests {
             .map(|s| s.repo.as_str())
             .collect();
         assert_eq!(floating, vec!["owner/a", "owner/c"]);
+    }
+
+    /// herdr has a first-class binding type for actions but none for panes, so panes go
+    /// through `type = "shell"` and the CLI. Getting this wrong writes a config line herdr
+    /// silently ignores — the user presses the key and nothing happens, with no error.
+    #[test]
+    fn actions_and_panes_produce_different_bindings() {
+        let (kind, cmd) =
+            BindTarget::Action("projects".into()).toml_fields("cloudmanic.herdr-plus");
+        assert_eq!(kind, "plugin_action");
+        assert_eq!(cmd, "cloudmanic.herdr-plus.projects");
+
+        let (kind, cmd) = BindTarget::Pane("list".into()).toml_fields("triage");
+        assert_eq!(
+            kind, "shell",
+            "herdr has no keybinding type for opening a pane"
+        );
+        assert_eq!(
+            cmd,
+            "herdr plugin pane open --plugin triage --entrypoint list"
+        );
+    }
+
+    #[test]
+    fn a_bind_target_reports_its_id() {
+        assert_eq!(BindTarget::Action("a".into()).id(), "a");
+        assert_eq!(BindTarget::Pane("p".into()).id(), "p");
+    }
+
+    /// Refusing on a conflict is the whole safety story for writing to someone's herdr
+    /// config: a second `[[keys.command]]` on the same key silently shadows the first, and
+    /// the user would have no idea which binding they lost.
+    #[test]
+    fn existing_bindings_are_detected() {
+        let config = r#"
+onboarding = false
+
+[[keys.command]]
+key = "prefix+shift+l"
+type = "plugin_action"
+command = "herdr-lazy.manage"
+
+# a commented-out one must not count
+# key = "prefix+shift+z"
+
+[[keys.command]]
+key   =    "ctrl+alt+g"
+command = "something.else"
+"#;
+        let keys = bound_keys(config);
+        assert!(keys.contains(&"prefix+shift+l".to_string()));
+        assert!(
+            keys.contains(&"ctrl+alt+g".to_string()),
+            "whitespace around = must not hide a binding"
+        );
+        assert!(
+            !keys.contains(&"prefix+shift+z".to_string()),
+            "a commented line is not a binding"
+        );
+    }
+
+    #[test]
+    fn an_empty_config_has_no_bindings() {
+        assert!(bound_keys("").is_empty());
+        assert!(bound_keys("onboarding = false\n[ui]\nx = 1\n").is_empty());
+    }
+
+    /// The config path comes from the socket herdr itself told us about, so a user with
+    /// XDG_CONFIG_HOME pointed elsewhere does not get a second config file herdr never reads.
+    #[test]
+    fn config_path_sits_beside_the_socket() {
+        // Safety: single-threaded test, and the variable is read immediately.
+        unsafe { env::set_var("HERDR_SOCKET_PATH", "/somewhere/odd/herdr.sock") };
+        assert_eq!(
+            herdr_config_path(),
+            Some(PathBuf::from("/somewhere/odd/config.toml"))
+        );
+        unsafe { env::remove_var("HERDR_SOCKET_PATH") };
+        assert_eq!(herdr_config_path(), None, "no socket, no guessing");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -219,6 +219,15 @@ struct App {
     detail_of: Option<usize>,
     /// Which action is highlighted in the details view.
     detail_cursor: usize,
+    /// Set while waiting for the letter to bind an action to.
+    awaiting_bind: bool,
+    /// `(action_id, key)` chosen but not yet written, while the user confirms.
+    ///
+    /// Writing to `config.toml` cannot be sandboxed: the pane is launched by herdr, so an
+    /// environment variable set in a shell never reaches it, and there is no "try it against
+    /// a copy" mode to offer. The only honest safeguard is to show exactly what will be
+    /// appended, and to where, before touching the file.
+    pending_bind: Option<(crate::BindTarget, String)>,
     cursor: usize,
     /// Set when a refresh fails, so the pane explains itself instead of showing an empty list.
     error: Option<String>,
@@ -241,6 +250,8 @@ impl App {
                 help: false,
                 detail_of: None,
                 detail_cursor: 0,
+                awaiting_bind: false,
+                pending_bind: None,
                 cursor: 0,
                 error: None,
                 flash: None,
@@ -251,6 +262,8 @@ impl App {
                 help: false,
                 detail_of: None,
                 detail_cursor: 0,
+                awaiting_bind: false,
+                pending_bind: None,
                 cursor: 0,
                 error: Some(e),
                 flash: None,
@@ -306,16 +319,92 @@ impl App {
         }
     }
 
+    /// Bind the highlighted action to `prefix+shift+<letter>`.
+    ///
+    /// Shift is not negotiable here: herdr's own defaults live on `prefix+<letter>`, and this
+    /// cannot see them (the CLI does not expose them), so the one thing it can do is stay out
+    /// of that space entirely. Conflicts with the user's own bindings are detected.
+    /// Everything in this plugin that a key could be bound to, in the order shown.
+    ///
+    /// Actions first, then panes. Panes are included because four of the seven plugins in the
+    /// default set expose only a pane — leaving them unbindable would mean the feature does
+    /// not work for most of what a new user has installed.
+    fn bindable(d: &PluginDetail) -> Vec<(crate::BindTarget, String)> {
+        let mut out: Vec<(crate::BindTarget, String)> = d
+            .actions
+            .iter()
+            .map(|(id, title)| {
+                (
+                    crate::BindTarget::Action(id.clone()),
+                    if title.is_empty() {
+                        id.clone()
+                    } else {
+                        title.clone()
+                    },
+                )
+            })
+            .collect();
+        out.extend(d.panes.iter().map(|(id, title, _)| {
+            (
+                crate::BindTarget::Pane(id.clone()),
+                if title.is_empty() {
+                    id.clone()
+                } else {
+                    title.clone()
+                },
+            )
+        }));
+        out
+    }
+
+    fn bind_selected(&mut self, letter: char) {
+        let Some(idx) = self.detail_of else { return };
+        let Some(d) = self.rows.get(idx).and_then(|r| r.detail.clone()) else {
+            return;
+        };
+        let Some((target, _)) = Self::bindable(&d).into_iter().nth(self.detail_cursor) else {
+            return;
+        };
+        let key = format!("prefix+shift+{}", letter.to_ascii_lowercase());
+        // Check for a conflict now, so the confirmation screen is never shown for a binding
+        // that would be refused anyway.
+        if let Err(msg) = crate::check_bind_conflict(&key) {
+            self.flash = Some(msg);
+            return;
+        }
+        self.pending_bind = Some((target, key));
+    }
+
+    /// `y` on the confirmation screen.
+    fn commit_bind(&mut self) {
+        let Some((target, key)) = self.pending_bind.take() else {
+            return;
+        };
+        let Some(d) = self
+            .detail_of
+            .and_then(|i| self.rows.get(i))
+            .and_then(|r| r.detail.clone())
+        else {
+            return;
+        };
+        self.flash = Some(match crate::bind_action(&d.plugin_id, &target, &key) {
+            Ok(msg) | Err(msg) => msg,
+        });
+    }
+
     fn run_detail_action(&mut self) {
         let Some(idx) = self.detail_of else { return };
         let Some(d) = self.rows.get(idx).and_then(|r| r.detail.clone()) else {
             return;
         };
-        let Some((action_id, _)) = d.actions.get(self.detail_cursor).cloned() else {
-            self.flash = Some("no actions to run".to_string());
+        let Some((target, _)) = Self::bindable(&d).into_iter().nth(self.detail_cursor) else {
+            self.flash = Some("nothing to run".to_string());
             return;
         };
-        self.flash = Some(crate::invoke_action(&d.plugin_id, &action_id));
+        self.flash = Some(match &target {
+            crate::BindTarget::Action(id) => crate::invoke_action(&d.plugin_id, id),
+            crate::BindTarget::Pane(id) => crate::open_pane(&d.plugin_id, id),
+        });
     }
 
     fn any_picked(&self) -> bool {
@@ -663,6 +752,9 @@ impl App {
         if self.help {
             return self.draw_help(out, width, height);
         }
+        if self.pending_bind.is_some() {
+            return self.draw_bind_confirm(out, width, height);
+        }
         if self.detail_of.is_some() {
             return self.draw_detail(out, width, height);
         }
@@ -670,6 +762,56 @@ impl App {
             return self.draw_browser(out, width, height);
         }
         self.draw_list(out, width, height)
+    }
+
+    /// Show the exact change before making it.
+    fn draw_bind_confirm(&self, out: &mut impl Write, width: u16, height: u16) -> io::Result<()> {
+        let rule = "─".repeat((width as usize).clamp(20, 200));
+        let (target, key) = self.pending_bind.clone().expect("checked by caller");
+        let plugin_id = self
+            .detail_of
+            .and_then(|i| self.rows.get(i))
+            .and_then(|r| r.detail.as_ref())
+            .map(|d| d.plugin_id.clone())
+            .unwrap_or_default();
+        let path = crate::herdr_config_path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "(herdr's config.toml — location unknown)".to_string());
+
+        write!(out, "\x1b[H\x1b[2J")?;
+        writeln!(out, "\x1b[1m bind {}.{}\x1b[0m\r", plugin_id, target.id())?;
+        writeln!(out, "\x1b[2m{}\x1b[0m\r", rule)?;
+        writeln!(out, " This appends to \x1b[1m{}\x1b[0m:\r", path)?;
+        writeln!(out, "\r")?;
+        let (kind, command) = crate::bind_toml_fields(&target, &plugin_id);
+        for line in [
+            "# added by herdr-lazy".to_string(),
+            "[[keys.command]]".to_string(),
+            format!("key = \"{}\"", key),
+            format!("type = \"{}\"", kind),
+            format!("command = \"{}\"", command),
+        ] {
+            writeln!(out, "   \x1b[32m{}\x1b[0m\r", line)?;
+        }
+        writeln!(out, "\r")?;
+        writeln!(
+            out,
+            " \x1b[2mYour current config is copied to config.toml.herdr-lazy-backup first.\x1b[0m\r"
+        )?;
+        writeln!(
+            out,
+            " \x1b[2mThis is your real herdr config — the pane is launched by herdr, so there \
+             is no copy to test against.\x1b[0m\r"
+        )?;
+
+        write!(
+            out,
+            "\x1b[{};1H\x1b[2m{}\r\n \x1b[0m\x1b[1m[y]\x1b[0m write it  \
+             \x1b[1m[n / esc]\x1b[0m cancel\r",
+            height.saturating_sub(1),
+            rule
+        )?;
+        out.flush()
     }
 
     /// What this plugin does, and how to actually use it.
@@ -702,6 +844,8 @@ impl App {
             return out.flush();
         };
 
+        let items = Self::bindable(d);
+
         if !d.description.is_empty() {
             for line in wrap(&d.description, (width as usize).saturating_sub(3)) {
                 writeln!(out, " {}\r", line)?;
@@ -709,7 +853,7 @@ impl App {
             writeln!(out, "\r")?;
         }
 
-        if d.actions.is_empty() && d.panes.is_empty() && d.events.is_empty() {
+        if items.is_empty() && d.events.is_empty() {
             writeln!(
                 out,
                 " \x1b[2mthis plugin declares no actions, panes or events — it may work \
@@ -717,28 +861,31 @@ impl App {
             )?;
         }
 
-        if !d.actions.is_empty() {
-            writeln!(out, " \x1b[1mthings you can run\x1b[0m  \x1b[2m(enter runs the highlighted one)\x1b[0m\r")?;
-            for (i, (id, title)) in d.actions.iter().enumerate() {
+        // Actions and panes in one list, because `enter` and `b` treat them the same way and
+        // the cursor indexes into it. Two separate sections would mean two things claiming to
+        // be "the highlighted one".
+        if !items.is_empty() {
+            writeln!(
+                out,
+                " \x1b[1mthings you can run\x1b[0m  \x1b[2m(enter runs it · b binds it to a key)\x1b[0m\r"
+            )?;
+            for (i, (target, label)) in items.iter().enumerate() {
                 let sel = if i == self.detail_cursor {
                     "\x1b[7m>"
                 } else {
                     " "
                 };
-                let label = if title.is_empty() { id } else { title };
-                writeln!(out, "{}\x1b[0m  {:<44} \x1b[2m{}\x1b[0m\r", sel, label, id)?;
-            }
-            writeln!(out, "\r")?;
-        }
-
-        if !d.panes.is_empty() {
-            writeln!(out, " \x1b[1mpanes it can open\x1b[0m\r")?;
-            for (id, title, placement) in &d.panes {
-                let label = if title.is_empty() { id } else { title };
+                let kind = match target {
+                    crate::BindTarget::Action(_) => "action",
+                    crate::BindTarget::Pane(_) => "pane",
+                };
                 writeln!(
                     out,
-                    "   {:<44} \x1b[2m{} · herdr plugin pane open --plugin {} --entrypoint {}\x1b[0m\r",
-                    label, placement, d.plugin_id, id
+                    "{}\x1b[0m  {:<44} \x1b[2m{:<7}{}\x1b[0m\r",
+                    sel,
+                    truncate(label, 44),
+                    kind,
+                    target.id()
                 )?;
             }
             writeln!(out, "\r")?;
@@ -753,24 +900,28 @@ impl App {
             writeln!(out, "\r")?;
         }
 
-        if !d.actions.is_empty() {
+        if let Some((target, _)) = items.get(self.detail_cursor) {
+            // Show the lines that `b` would actually write, not a fixed example — panes and
+            // actions produce different `type` values, and a wrong example here would send
+            // someone to hand-write a binding herdr ignores.
+            let (kind, command) = crate::bind_toml_fields(target, &d.plugin_id);
             writeln!(
                 out,
-                " \x1b[2mbind one to a key:  [[keys.command]] type = \"plugin_action\" \
-                 command = \"{}.{}\"\x1b[0m\r",
-                d.plugin_id,
-                d.actions
-                    .get(self.detail_cursor)
-                    .map(|(id, _)| id.as_str())
-                    .unwrap_or("<action>")
+                " \x1b[2mb binds the highlighted one:  type = \"{}\"  command = \"{}\"\x1b[0m\r",
+                kind, command
             )?;
         }
 
-        let footer = match &self.flash {
-            Some(m) => format!("\x1b[36m{}\x1b[0m", m),
-            None => "\x1b[1m[enter]\x1b[0m run  \x1b[1m[j/k]\x1b[0m move  \
-                     \x1b[1m[esc]\x1b[0m back"
-                .to_string(),
+        let footer = if self.awaiting_bind {
+            "\x1b[33mpress a letter to bind this to prefix+shift+<letter>, or esc\x1b[0m"
+                .to_string()
+        } else {
+            match &self.flash {
+                Some(m) => format!("\x1b[36m{}\x1b[0m", m),
+                None => "\x1b[1m[enter]\x1b[0m run  \x1b[1m[b]\x1b[0m bind to a key  \
+                         \x1b[1m[j/k]\x1b[0m move  \x1b[1m[esc]\x1b[0m back"
+                    .to_string(),
+            }
         };
         write!(
             out,
@@ -849,7 +1000,10 @@ impl App {
             out,
             "finding your way",
             &[
-                ("l / →", "what this plugin does, and run its actions"),
+                (
+                    "l / →",
+                    "what this plugin does — run its actions, or bind one to a key",
+                ),
                 ("j / k", "down / up  (arrows and the wheel work too)"),
                 ("g / G", "first / last row"),
                 (
@@ -1205,12 +1359,24 @@ fn event_loop(out: &mut impl Write) -> io::Result<()> {
         }
 
         // Details view: a short list of runnable actions.
+        // Confirmation is modal: only y / n / esc mean anything here.
+        if app.pending_bind.is_some() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => app.commit_bind(),
+                _ => {
+                    app.pending_bind = None;
+                    app.flash = Some("not bound".to_string());
+                }
+            }
+            continue;
+        }
+
         if let Some(idx) = app.detail_of {
             let n = app
                 .rows
                 .get(idx)
                 .and_then(|r| r.detail.as_ref())
-                .map(|d| d.actions.len())
+                .map(|d| App::bindable(d).len())
                 .unwrap_or(0);
             // Ctrl-chords first: a plain `j` moves, but Ctrl+J is a pty's Enter, and a
             // later arm would never see it.
@@ -1222,7 +1388,32 @@ fn event_loop(out: &mut impl Write) -> io::Result<()> {
                 }
                 continue;
             }
+            // Waiting for the letter to bind to: take it and nothing else.
+            if app.awaiting_bind {
+                app.awaiting_bind = false;
+                match key.code {
+                    KeyCode::Char(c) if c.is_ascii_alphabetic() => app.bind_selected(c),
+                    KeyCode::Esc => app.flash = Some("not bound".to_string()),
+                    _ => app.flash = Some("that is not a letter — nothing bound".to_string()),
+                }
+                continue;
+            }
+
             match key.code {
+                KeyCode::Char('b') => {
+                    if app
+                        .rows
+                        .get(idx)
+                        .and_then(|r| r.detail.as_ref())
+                        .map(|d| App::bindable(d).is_empty())
+                        .unwrap_or(true)
+                    {
+                        app.flash = Some("no actions to bind".to_string());
+                    } else {
+                        app.awaiting_bind = true;
+                        app.flash = None;
+                    }
+                }
                 KeyCode::Esc | KeyCode::Char('q') => {
                     app.detail_of = None;
                     app.flash = None;
@@ -1778,6 +1969,56 @@ mod tests {
 
         app.clear_picks();
         assert_eq!(app.targets(), vec![app.cursor]);
+    }
+
+    /// The bug this pins down: `b` only ever offered actions, and four of the seven plugins
+    /// in the default set expose a pane and no actions at all. Pressing `b` on those said
+    /// "no actions to bind" — so for most of what a new user has installed, the feature did
+    /// nothing.
+    #[test]
+    fn panes_are_bindable_not_just_actions() {
+        let pane_only = PluginDetail {
+            plugin_id: "triage".into(),
+            panes: vec![("list".into(), "Triage".into(), "split".into())],
+            ..Default::default()
+        };
+        let items = App::bindable(&pane_only);
+        assert_eq!(items.len(), 1, "a pane-only plugin must still be bindable");
+        assert_eq!(items[0].0, crate::BindTarget::Pane("list".into()));
+        assert_eq!(items[0].1, "Triage");
+
+        let neither = PluginDetail {
+            plugin_id: "x".into(),
+            ..Default::default()
+        };
+        assert!(App::bindable(&neither).is_empty());
+    }
+
+    /// Actions come first, then panes, and the order must match what is drawn — the cursor
+    /// indexes into this list, so a mismatch binds the wrong thing.
+    #[test]
+    fn bindable_lists_actions_before_panes() {
+        let both = PluginDetail {
+            plugin_id: "p".into(),
+            actions: vec![("run".into(), "Run it".into())],
+            panes: vec![("side".into(), "Sidebar".into(), "split".into())],
+            ..Default::default()
+        };
+        let items = App::bindable(&both);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].0, crate::BindTarget::Action("run".into()));
+        assert_eq!(items[1].0, crate::BindTarget::Pane("side".into()));
+    }
+
+    /// A missing title falls back to the id, so a row is never blank.
+    #[test]
+    fn an_untitled_entry_shows_its_id() {
+        let d = PluginDetail {
+            plugin_id: "p".into(),
+            actions: vec![("bare".into(), String::new())],
+            ..Default::default()
+        };
+        assert_eq!(App::bindable(&d)[0].1, "bare");
     }
 
     #[test]


### PR DESCRIPTION
## What and why

herdr has no command palette, and a plugin manifest has no field for suggesting a keybinding.
So a plugin's actions are unreachable from the keyboard until the user writes a
`[[keys.command]]` block into `config.toml` — having first worked out that the action exists,
which nothing in herdr tells them either.

The details view (`l`) already lists what a plugin offers, read from `plugin list --json`.
This adds the last step: `b` then a letter writes the binding.

## Panes too, not just actions

herdr has a first-class binding type for actions (`plugin_action`) but **none for opening a
pane**. Those are written as `type = "shell"` running
`herdr plugin pane open --plugin … --entrypoint …`.

This is not a nicety: four of the seven plugins in the default set (`triage`, `green`,
`standup`, `hail`) declare a pane and no actions at all. Binding actions only meant `b`
answered "no actions to bind" for most of what a new user has installed.

## Confirmation, and why it is not optional

```
 This appends to /Users/you/.config/herdr/config.toml:

   # added by herdr-lazy
   [[keys.command]]
   key = "prefix+shift+z"
   type = "shell"
   command = "herdr plugin pane open --plugin triage --entrypoint list"

 [y] write it   [n / esc] cancel
```

The pane is launched by herdr, so an environment variable set in a shell never reaches it —
there is no way to point this at a scratch file and try it safely first. Showing the exact
lines before writing them is the only honest safeguard available.

Alongside that:

- **Refuses on conflict.** A second `[[keys.command]]` on the same key silently shadows the
  first, and the user would have no way to tell which binding they lost.
- **Backs up first**, to `config.toml.herdr-lazy-backup`.
- **Marks what it added** with `# added by herdr-lazy`.
- **Reloads herdr's config**, so the key works without a restart.

## Why shift is forced

herdr's defaults live on `prefix+<letter>` and are **not exposed by the CLI** — there is no
way to ask which are taken. Binding into that range would risk shadowing a built-in with no
way to detect it. `prefix+shift+<letter>` is the one range this can offer safely.

## Where the config path comes from

Derived from `HERDR_SOCKET_PATH` (the socket sits in herdr's config directory) rather than
assuming `~/.config/herdr`. A user with `XDG_CONFIG_HOME` elsewhere would otherwise get a
second config file herdr never reads.

## Tests

74 pass. New coverage concentrates on what can damage a setup or mislead:

- actions and panes produce different `type`/`command` — writing the wrong one produces a
  config line herdr silently ignores, so the key does nothing and says nothing
- a pane-only plugin is bindable, and actions sort before panes (the cursor indexes into that
  list, so a mismatch binds the wrong entry)
- existing bindings are detected, including odd whitespace; commented-out lines are not
  mistaken for bindings
- the config path is derived from the socket, and is `None` rather than a guess without one

Verified end-to-end: binding writes, a conflict refuses and leaves the file byte-identical,
`n`/`esc` cancels, and the on-screen example matches what actually gets written.

## Checklist

- [x] `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` pass
- [x] New behaviour has a test
- [x] No new dependency

This writes to the user's herdr config, so the guards above are as much the point of the
change as the feature is.
