### PR TITLE
Mark plugins whose repo has moved since install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ machine. herdr-lazy adds both.
 - **A real lockfile.** Entries pin to a commit, and the lock records the commit herdr
   actually checked out. Copy the lock to another machine, `sync`, and you get the same
   plugins at the same commits.
+- **A hint when something has moved.** `↑` marks a plugin whose repository has been pushed
+  to since you installed it, so `u` is worth pressing.
 - **A manage pane.** A herdr overlay pane with the same operations on single keys —
   `i`/`u`/`x`/`r` as in lazy.nvim. Tick rows with space or a click to act on several at
   once, or act on just the row under the cursor when nothing is ticked. `?` shows the full
@@ -191,6 +193,22 @@ variable set in your shell never reaches it — there is no way to point this at
 and try it safely. Your config is copied to `config.toml.herdr-lazy-backup` before the first
 write, every added block is marked `# added by herdr-lazy`, and a key that is already bound
 is refused rather than shadowed.
+
+## Spotting updates
+
+`↑` beside a commit means the plugin's repository has been pushed to since that copy was
+installed, and the header counts how many. `u` updates them.
+
+It is a hint, and worded as one. The comparison is between the marketplace index's
+`pushedAt` and when herdr fetched the plugin, so a push to any branch counts even if the
+default branch — the thing that actually gets installed — has not moved. Erring toward
+reporting is deliberate: a needless `u` costs a moment, while a missed update stays missed.
+
+Pinned entries are never marked. A pin means "this commit, deliberately", and flagging it
+would teach you to ignore the marker.
+
+This costs no network access. It reads the marketplace index that browsing already cached;
+with nothing cached, the column is simply absent.
 
 ## Acting on several at once
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,9 @@ pub(crate) struct Installed {
     /// `owner/repo` rebuilt from `source.owner` + `source.repo`. herdr stores them as two
     /// separate fields, never as a joined slug, so this has to be assembled.
     pub(crate) slug: Option<String>,
+    /// `source.installed_unix_ms` — when herdr fetched this. Compared against the
+    /// marketplace's `pushedAt` to spot plugins that have moved since.
+    pub(crate) installed_unix_ms: Option<u64>,
     /// `source.resolved_commit` — the exact commit herdr checked out. This is what makes a
     /// lockfile real: we can record what is actually installed, not merely what was asked for.
     pub(crate) resolved_commit: Option<String>,
@@ -425,6 +428,12 @@ fn parse_plugin_list(stdout: &str) -> Result<Vec<Installed>, String> {
                             .collect()
                     })
                     .unwrap_or_default(),
+                installed_unix_ms: p
+                    .path(&["source", "installed_unix_ms"])
+                    .and_then(|v| match v {
+                        json::Value::Num(n) if *n >= 0.0 => Some(*n as u64),
+                        _ => None,
+                    }),
                 slug,
                 resolved_commit: p
                     .path(&["source", "resolved_commit"])

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -27,7 +27,7 @@ const INDEX_URL: &str = "https://assets.herdr.dev/plugins/index.json";
 const CACHE_SECONDS: u64 = 6 * 60 * 60;
 
 /// One plugin as the marketplace describes it.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub(crate) struct Entry {
     pub(crate) full_name: String,
     pub(crate) description: String,
@@ -99,6 +99,28 @@ pub(crate) fn age_label(pushed_at: &str, today: i64) -> String {
         30..=364 => format!("{}mo", days / 30),
         _ => format!("{}y", days / 365),
     }
+}
+
+/// Has this repository been pushed to since the given instant?
+///
+/// The comparison behind the "update?" marker. Both halves are approximations and the result
+/// is worded as a question on purpose:
+///
+///   - `pushedAt` is the last push to *any* branch, so a tag or a topic branch counts even
+///     though the default branch — the thing herdr installs — has not moved.
+///   - a plugin installed at a pinned commit is deliberately not tracking the branch, so it
+///     is excluded by the caller rather than reported as stale.
+///
+/// A false "maybe" costs a wasted `u`; a false "you are current" would hide real updates,
+/// which is the worse failure, so it errs toward reporting.
+pub(crate) fn pushed_since(pushed_at: &str, installed_unix_ms: u64) -> bool {
+    let Some(pushed_day) = days_from_iso(pushed_at) else {
+        return false;
+    };
+    let installed_day = (installed_unix_ms / 1000 / 86_400) as i64;
+    // Day resolution: the index only carries a date we can rely on parsing, and an install
+    // and a push on the same day is not worth flagging either way.
+    pushed_day > installed_day
 }
 
 /// Today, as days since the epoch.
@@ -235,6 +257,17 @@ pub(crate) fn load(force: bool) -> Result<(Vec<Entry>, String), String> {
     }
 }
 
+/// Entries from the cache, or nothing. Never fetches.
+///
+/// Used by the list view, which runs on every keypress-driven redraw and must not depend on
+/// the network being there — or on someone else's CDN being willing.
+pub(crate) fn cached_entries() -> Vec<Entry> {
+    fs::read_to_string(cache_path())
+        .ok()
+        .and_then(|b| parse_index(&b).ok())
+        .unwrap_or_default()
+}
+
 fn write_cache(body: &str) -> io::Result<()> {
     let p = cache_path();
     if let Some(parent) = p.parent() {
@@ -300,6 +333,29 @@ mod tests {
         );
         assert_eq!(days_from_iso("not a date"), None);
         assert_eq!(days_from_iso("2026-13-01"), None, "month out of range");
+    }
+
+    #[test]
+    fn a_push_after_the_install_is_reported() {
+        let day = 86_400_000u64;
+        // installed on day 20000, pushed on day 20001
+        let installed = 20_000 * day;
+        assert!(
+            pushed_since("2024-10-05T00:00:00Z", 0),
+            "any push beats epoch"
+        );
+        assert!(!pushed_since("", installed), "no date, no claim");
+        assert!(!pushed_since("not a date", installed));
+    }
+
+    #[test]
+    fn same_day_is_not_an_update() {
+        // 2026-07-21 as ms; a push the same day must not be flagged.
+        let d = days_from_iso("2026-07-21").unwrap() as u64;
+        let installed_ms = d * 86_400_000;
+        assert!(!pushed_since("2026-07-21T23:59:00Z", installed_ms));
+        assert!(pushed_since("2026-07-22T00:01:00Z", installed_ms));
+        assert!(!pushed_since("2026-07-20T00:01:00Z", installed_ms));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -105,6 +105,9 @@ struct Row {
     /// `owner/repo`, when known — what `a` adds. `None` for a local link, which has no repo
     /// to record, so it can never be adopted into the list.
     slug: Option<String>,
+    /// The plugin's repository has been pushed to since this copy was installed. A hint, not
+    /// a fact — see `registry::pushed_since`.
+    maybe_stale: bool,
     /// herdr's id for the installed plugin, and how it was installed. Present only when the
     /// row corresponds to something actually installed — which is exactly when `x` applies.
     installed: Option<(String, String)>,
@@ -137,7 +140,37 @@ fn detail_of(p: &Installed) -> PluginDetail {
 }
 
 /// Build the view: every bundle entry, then anything installed that the bundle does not name.
+/// The view without update information — what the tests use, since they are checking status
+/// and selection rather than what the marketplace happens to say today.
+#[cfg(test)]
 fn rows(desired: &[Spec], installed: &[Installed]) -> Vec<Row> {
+    rows_with_updates(desired, installed, &[])
+}
+
+/// Build the view, marking anything the marketplace says has moved since it was installed.
+///
+/// `market` is whatever is already cached; browsing has usually populated it, and when it is
+/// empty the column simply does not appear. Checking for updates should never be the reason
+/// the pane makes a network call.
+fn rows_with_updates(
+    desired: &[Spec],
+    installed: &[Installed],
+    market: &[crate::registry::Entry],
+) -> Vec<Row> {
+    let stale = |p: &Installed, spec: Option<&Spec>| -> bool {
+        // A pinned entry is meant to sit still; calling it out of date is noise.
+        if spec.map(|s| s.reference.is_some()).unwrap_or(false) {
+            return false;
+        }
+        let (Some(slug), Some(ms)) = (p.slug.as_ref(), p.installed_unix_ms) else {
+            return false;
+        };
+        market
+            .iter()
+            .find(|e| e.full_name.eq_ignore_ascii_case(slug))
+            .map(|e| crate::registry::pushed_since(&e.pushed_at, ms))
+            .unwrap_or(false)
+    };
     let mut rows = Vec::new();
 
     for spec in desired {
@@ -167,6 +200,7 @@ fn rows(desired: &[Spec], installed: &[Installed]) -> Vec<Row> {
             listed_as: Some(spec.display()),
             slug: Some(spec.repo.clone()),
             installed: hit.map(|(p, _)| (p.plugin_id.clone(), p.source_kind.clone())),
+            maybe_stale: hit.map(|(p, _)| stale(p, Some(spec))).unwrap_or(false),
             picked: false,
             detail: hit.map(|(p, _)| detail_of(p)),
         });
@@ -190,6 +224,7 @@ fn rows(desired: &[Spec], installed: &[Installed]) -> Vec<Row> {
             listed_as: None,
             slug: p.slug.clone(),
             installed: Some((p.plugin_id.clone(), p.source_kind.clone())),
+            maybe_stale: stale(p, None),
             picked: false,
             detail: Some(detail_of(p)),
         });
@@ -243,9 +278,12 @@ impl App {
             .iter()
             .map(|l| Spec::parse(l))
             .collect();
+        // Cached only: `false` never fetches. If nothing is cached the update column is
+        // simply absent, which is better than making every pane open hit the network.
+        let market = crate::registry::cached_entries();
         match installed_plugins() {
             Ok(installed) => App {
-                rows: rows(&desired, &installed),
+                rows: rows_with_updates(&desired, &installed, &market),
                 browser: None,
                 help: false,
                 detail_of: None,
@@ -1103,6 +1141,7 @@ impl App {
         let ok = counts(|s| *s == Status::Ok);
         let todo = counts(|s| matches!(s, Status::Missing | Status::Drifted { .. }));
         let extra = counts(|s| *s == Status::Extra);
+        let stale = self.rows.iter().filter(|r| r.maybe_stale).count();
 
         // Showing auto-sync here is the only way a user learns it exists: it has no row of its
         // own, and something that installs software at startup should be visible, not buried.
@@ -1113,8 +1152,16 @@ impl App {
         };
         writeln!(
             out,
-            "\x1b[1m herdr-lazy\x1b[0m  \x1b[2m{} ok · {} to sync · {} unlisted\x1b[0m{}\r",
-            ok, todo, extra, auto
+            "\x1b[1m herdr-lazy\x1b[0m  \x1b[2m{} ok · {} to sync · {} unlisted{}\x1b[0m{}\r",
+            ok,
+            todo,
+            extra,
+            if stale > 0 {
+                format!(" · \x1b[33m{} may have updates\x1b[0m\x1b[2m", stale)
+            } else {
+                String::new()
+            },
+            auto
         )?;
         writeln!(out, "\x1b[2m{}\x1b[0m\r", rule)?;
 
@@ -1150,16 +1197,32 @@ impl App {
                 .as_deref()
                 .map(crate::short)
                 .unwrap_or_else(|| "-".to_string());
-            let note = row.status.note();
+            // `↑` next to the commit rather than a column of its own: it qualifies the commit
+            // that is shown, and the row is already wide.
+            let up = if row.maybe_stale {
+                "\x1b[33m↑\x1b[0m"
+            } else {
+                " "
+            };
+            // The marker alone does not say what it means; on an otherwise-quiet row there is
+            // space to say it.
+            let note = match (row.maybe_stale, row.status.note()) {
+                (true, n) if n.is_empty() => {
+                    "its repo has been pushed to since you installed — press u to update"
+                        .to_string()
+                }
+                (_, n) => n,
+            };
             writeln!(
                 out,
-                "{} {}{}{}\x1b[0m {:<44} \x1b[2m{:<12}\x1b[0m {}\x1b[0m\r",
+                "{} {}{}{}\x1b[0m {:<44} \x1b[2m{:<12}\x1b[0m{} {}\x1b[0m\r",
                 pointer,
                 box_,
                 row.status.colour(),
                 row.status.marker(),
                 truncate(&row.label, 44),
                 commit,
+                up,
                 if note.is_empty() {
                     String::new()
                 } else {
@@ -2019,6 +2082,69 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(App::bindable(&d)[0].1, "bare");
+    }
+
+    fn market(name: &str, pushed_at: &str) -> crate::registry::Entry {
+        crate::registry::Entry {
+            full_name: name.to_string(),
+            pushed_at: pushed_at.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn installed_at(owner: &str, repo: &str, ms: u64) -> Installed {
+        let mut p = github(owner, repo, SHA, true);
+        p.installed_unix_ms = Some(ms);
+        p
+    }
+
+    /// Day 20000 of the epoch, in ms — a fixed point so the test does not drift with the clock.
+    const DAY_MS: u64 = 86_400_000;
+
+    #[test]
+    fn a_repo_pushed_after_install_is_flagged() {
+        let desired = vec![Spec::parse("o/moved"), Spec::parse("o/still")];
+        let installed = vec![
+            installed_at("o", "moved", 20_000 * DAY_MS),
+            installed_at("o", "still", 20_010 * DAY_MS),
+        ];
+        let market = vec![
+            market("o/moved", "2024-10-05T00:00:00Z"), // long after day 20000
+            market("o/still", "1970-01-05T00:00:00Z"), // long before
+        ];
+        let r = rows_with_updates(&desired, &installed, &market);
+        assert!(r[0].maybe_stale, "a later push must be reported");
+        assert!(!r[1].maybe_stale, "an older push must not be");
+    }
+
+    /// A pin says "this commit, deliberately". Reporting it as out of date would train people
+    /// to ignore the marker.
+    #[test]
+    fn a_pinned_entry_is_never_flagged() {
+        let sha = "10e93033263549600e75119c5617dac48137d011";
+        let desired = vec![Spec::parse(&format!("o/pinned@{}", sha))];
+        let installed = vec![installed_at("o", "pinned", 20_000 * DAY_MS)];
+        let market = vec![market("o/pinned", "2024-10-05T00:00:00Z")];
+        assert!(!rows_with_updates(&desired, &installed, &market)[0].maybe_stale);
+    }
+
+    /// With no cached index — a fresh install that has never opened the browser — the column
+    /// is simply absent. It must never become a reason to reach for the network.
+    #[test]
+    fn without_a_cached_index_nothing_is_flagged() {
+        let desired = vec![Spec::parse("o/x")];
+        let installed = vec![installed_at("o", "x", 0)];
+        assert!(!rows_with_updates(&desired, &installed, &[])[0].maybe_stale);
+    }
+
+    /// An unlisted plugin can be stale too — it is installed, and `u` would update it.
+    #[test]
+    fn unlisted_plugins_are_checked_as_well() {
+        let installed = vec![installed_at("someone", "extra", 20_000 * DAY_MS)];
+        let market = vec![market("someone/extra", "2024-10-05T00:00:00Z")];
+        let r = rows_with_updates(&[], &installed, &market);
+        assert_eq!(r.len(), 1);
+        assert!(r[0].maybe_stale);
     }
 
     #[test]


### PR DESCRIPTION
feat: mark plugins whose repo has moved since install

A list of installed plugins says nothing about whether any of them have
newer versions, so the only way to find out was to run `update` and see
what changed.

`↑` now marks a plugin whose repository has been pushed to since herdr
fetched it, and the header counts them.

- costs no network access: it compares `source.installed_unix_ms` against
  the `pushedAt` already present in the cached marketplace index. With
  nothing cached the column is simply absent, so opening the pane never
  becomes a reason to make a request
- pinned entries are never marked — a pin means "this commit,
  deliberately", and flagging it would teach people to ignore the marker
- worded as a hint. `pushedAt` covers pushes to any branch, so it can
  report a repo whose default branch has not moved. Erring toward
  reporting is the deliberate choice: a needless `u` costs a moment,
  a missed update stays missed
