### PR TITLE
Show what changed before you update

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,216 @@
+//! Just enough GitHub API to answer "what changed since I installed this?".
+//!
+//! The `↑` marker says a repo has been pushed to; it cannot say whether that push is worth
+//! pulling. This fetches the commit subjects between the installed commit and the current
+//! default branch, so the details view can show them before `u` is pressed.
+//!
+//! Deliberately narrow and fail-soft, like the marketplace: unauthenticated, one request per
+//! plugin and only when its details are opened, and any failure yields "could not check"
+//! rather than blocking the pane. The unauthenticated rate limit is 60/hour, which is ample
+//! when the trigger is a human opening one plugin's details, and hopeless for anything that
+//! tried to check everything at once — so nothing does.
+
+use std::process::Command;
+
+/// What changed since install, for the details view.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Changes {
+    /// Commit subjects newer than the installed commit, most recent first.
+    Commits(Vec<String>),
+    /// More than we asked for — the install is far enough behind that we stopped counting.
+    ManyPlus(usize),
+    /// Could not tell: offline, rate-limited, or the API shape was not what we expected.
+    Unknown(String),
+}
+
+const PAGE: usize = 30;
+
+/// Commit subjects on `owner/repo`'s default branch that are newer than `installed_commit`.
+pub(crate) fn changes_since(owner_repo: &str, installed_commit: &str) -> Changes {
+    if installed_commit.is_empty() {
+        return Changes::Unknown("no installed commit to compare against".to_string());
+    }
+    let url = format!(
+        "https://api.github.com/repos/{}/commits?per_page={}",
+        owner_repo, PAGE
+    );
+    let body = match fetch(&url) {
+        Some(b) => b,
+        None => return Changes::Unknown("could not reach github".to_string()),
+    };
+    parse_commits(&body, installed_commit)
+}
+
+/// Shell out to curl/wget — std has no TLS, the same reason the install script and the
+/// marketplace fetch do.
+fn fetch(url: &str) -> Option<String> {
+    let try_one = |prog: &str, args: &[&str]| -> Option<String> {
+        let out = Command::new(prog).args(args).output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let body = String::from_utf8_lossy(&out.stdout).to_string();
+        (!body.trim().is_empty()).then_some(body)
+    };
+    // A User-Agent is required by the GitHub API, or it answers 403.
+    try_one(
+        "curl",
+        &[
+            "-fsL",
+            "--max-time",
+            "15",
+            "-H",
+            "User-Agent: herdr-lazy",
+            "-H",
+            "Accept: application/vnd.github+json",
+            url,
+        ],
+    )
+    .or_else(|| {
+        try_one(
+            "wget",
+            &[
+                "-q",
+                "-O",
+                "-",
+                "--timeout=15",
+                "--header=User-Agent: herdr-lazy",
+                url,
+            ],
+        )
+    })
+}
+
+/// Walk the commit list until the installed commit appears; everything before it is new.
+///
+/// Kept separate from the fetch so it can be tested against captured payloads — the walk is
+/// where the off-by-one lives (is the installed commit itself "new"? no), and that is exactly
+/// what a test should pin rather than a live API.
+pub(crate) fn parse_commits(body: &str, installed_commit: &str) -> Changes {
+    let v = match crate::json::parse(body.trim()) {
+        Ok(v) => v,
+        Err(e) => return Changes::Unknown(format!("unexpected response: {}", e)),
+    };
+    let Some(arr) = v.as_array() else {
+        // The API returns an object (not an array) for errors like rate limiting.
+        let msg = v
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unexpected response shape");
+        return Changes::Unknown(msg.to_string());
+    };
+
+    let mut subjects = Vec::new();
+    for c in arr {
+        let sha = c.str_field("sha").unwrap_or_default();
+        // Match on a prefix: the installed commit may be recorded abbreviated.
+        if !installed_commit.is_empty()
+            && (sha == installed_commit || sha.starts_with(installed_commit))
+        {
+            return Changes::Commits(subjects);
+        }
+        let subject = c
+            .get("commit")
+            .and_then(|c| c.str_field("message"))
+            .unwrap_or("")
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string();
+        subjects.push(subject);
+    }
+
+    // Ran off the end without finding it: the install is more than a page behind, or the
+    // branch was force-pushed and the commit is gone. Either way, "many" is the honest answer.
+    Changes::ManyPlus(subjects.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(shas_and_subjects: &[(&str, &str)]) -> String {
+        let items: Vec<String> = shas_and_subjects
+            .iter()
+            .map(|(sha, subj)| {
+                format!(
+                    r#"{{"sha":"{}","commit":{{"message":"{}"}}}}"#,
+                    sha,
+                    subj.replace('"', "'")
+                )
+            })
+            .collect();
+        format!("[{}]", items.join(","))
+    }
+
+    #[test]
+    fn lists_commits_newer_than_the_installed_one() {
+        let body = payload(&[
+            ("ccc", "newest"),
+            ("bbb", "middle"),
+            ("aaa", "the installed one"),
+            ("999", "older, should not appear"),
+        ]);
+        assert_eq!(
+            parse_commits(&body, "aaa"),
+            Changes::Commits(vec!["newest".into(), "middle".into()])
+        );
+    }
+
+    #[test]
+    fn the_installed_commit_itself_is_not_a_change() {
+        let body = payload(&[("aaa", "the installed one")]);
+        assert_eq!(parse_commits(&body, "aaa"), Changes::Commits(vec![]));
+    }
+
+    #[test]
+    fn an_abbreviated_installed_commit_still_matches() {
+        let body = payload(&[("ccc", "new"), ("abcdef123456", "installed")]);
+        assert_eq!(
+            parse_commits(&body, "abcdef1"),
+            Changes::Commits(vec!["new".into()])
+        );
+    }
+
+    /// The install is further back than one page, so the count is a floor, not a total.
+    #[test]
+    fn a_missing_installed_commit_is_reported_as_many() {
+        let body = payload(&[("ccc", "a"), ("bbb", "b"), ("aaa", "c")]);
+        assert_eq!(
+            parse_commits(&body, "not-in-this-page"),
+            Changes::ManyPlus(3)
+        );
+    }
+
+    /// Rate-limit and other errors come back as a JSON object, not an array.
+    #[test]
+    fn an_api_error_object_is_reported_not_parsed_as_commits() {
+        let body = r#"{"message":"API rate limit exceeded","documentation_url":"..."}"#;
+        match parse_commits(body, "aaa") {
+            Changes::Unknown(m) => assert!(m.contains("rate limit")),
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn garbage_is_unknown_not_a_panic() {
+        assert!(matches!(
+            parse_commits("not json", "aaa"),
+            Changes::Unknown(_)
+        ));
+        assert!(matches!(
+            changes_since("owner/repo", ""),
+            Changes::Unknown(_)
+        ));
+    }
+
+    /// Only the first line of a commit message is a subject; the body must not leak in.
+    #[test]
+    fn only_the_subject_line_is_kept() {
+        let body = r#"[{"sha":"ccc","commit":{"message":"subject\n\nlong body here"}},{"sha":"aaa","commit":{"message":"installed"}}]"#;
+        assert_eq!(
+            parse_commits(body, "aaa"),
+            Changes::Commits(vec!["subject".into()])
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@
 //! only its name can be compared), and `--prune` acts on Strong only.
 
 mod browse;
+mod github;
 mod json;
 mod registry;
 mod ui;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -254,6 +254,10 @@ struct App {
     detail_of: Option<usize>,
     /// Which action is highlighted in the details view.
     detail_cursor: usize,
+    /// Changes fetched for the currently open details, and which row they belong to. Keyed by
+    /// row so reopening the same plugin does not re-hit the network, and a stale result for a
+    /// different plugin never shows.
+    detail_changes: Option<(usize, crate::github::Changes)>,
     /// Set while waiting for the letter to bind an action to.
     awaiting_bind: bool,
     /// `(action_id, key)` chosen but not yet written, while the user confirms.
@@ -288,6 +292,7 @@ impl App {
                 help: false,
                 detail_of: None,
                 detail_cursor: 0,
+                detail_changes: None,
                 awaiting_bind: false,
                 pending_bind: None,
                 cursor: 0,
@@ -300,6 +305,7 @@ impl App {
                 help: false,
                 detail_of: None,
                 detail_cursor: 0,
+                detail_changes: None,
                 awaiting_bind: false,
                 pending_bind: None,
                 cursor: 0,
@@ -312,9 +318,11 @@ impl App {
     fn refresh(&mut self) {
         let (cursor, flash) = (self.cursor, self.flash.take());
         let (browser, help) = (self.browser.take(), self.help);
+        let changes = self.detail_changes.take();
         *self = App::load();
         self.browser = browser;
         self.help = help;
+        self.detail_changes = changes;
         self.cursor = cursor.min(self.rows.len().saturating_sub(1));
         self.flash = flash;
     }
@@ -350,10 +358,29 @@ impl App {
     }
 
     fn open_detail(&mut self) {
-        if self.rows.get(self.cursor).is_some() {
-            self.detail_of = Some(self.cursor);
-            self.detail_cursor = 0;
-            self.flash = None;
+        let Some(row) = self.rows.get(self.cursor) else {
+            return;
+        };
+        self.detail_of = Some(self.cursor);
+        self.detail_cursor = 0;
+        self.flash = None;
+
+        // Fetch only for a plugin the offline marker already flagged. Opening the details of
+        // an up-to-date plugin must stay instant — going to the network for every `l` would
+        // make the common case (nothing changed) the slow one, which is backwards. The marker
+        // can lag a very recent push by up to a day; that a just-pushed plugin waits one more
+        // day for its diff is a fair price for `l` never blocking on a plugin that is current.
+        //
+        // Reuse a result already fetched for this row so reopening does not re-hit the network.
+        if matches!(&self.detail_changes, Some((i, _)) if *i == self.cursor) {
+            return;
+        }
+        self.detail_changes = None;
+        if row.maybe_stale {
+            if let (Some(slug), Some(commit)) = (row.slug.clone(), row.commit.clone()) {
+                let changes = crate::github::changes_since(&slug, &commit);
+                self.detail_changes = Some((self.cursor, changes));
+            }
         }
     }
 
@@ -938,6 +965,52 @@ impl App {
             writeln!(out, "\r")?;
         }
 
+        // What changed since install — the point of the whole feature. Only present when this
+        // plugin was flagged and the fetch happened on open; a plugin with no marker shows
+        // nothing here, which is correct.
+        if let Some((row_idx, changes)) = &self.detail_changes {
+            if *row_idx == idx {
+                use crate::github::Changes;
+                match changes {
+                    Changes::Commits(cs) if !cs.is_empty() => {
+                        writeln!(
+                            out,
+                            " \x1b[1m\x1b[33m{} new commit(s) since you installed\x1b[0m  \
+                             \x1b[2m(press u to update)\x1b[0m\r",
+                            cs.len()
+                        )?;
+                        for subject in cs.iter().take(8) {
+                            writeln!(
+                                out,
+                                "   \x1b[2m·\x1b[0m {}\r",
+                                truncate(subject, width.saturating_sub(6) as usize)
+                            )?;
+                        }
+                        if cs.len() > 8 {
+                            writeln!(out, "   \x1b[2m… and {} more\x1b[0m\r", cs.len() - 8)?;
+                        }
+                        writeln!(out, "\r")?;
+                    }
+                    Changes::Commits(_) => {} // marker was stale; nothing actually newer
+                    Changes::ManyPlus(n) => {
+                        writeln!(
+                            out,
+                            " \x1b[33m{}+ commits behind\x1b[0m \x1b[2m— more than one page; \
+                             press u to catch up\x1b[0m\r\r",
+                            n
+                        )?;
+                    }
+                    Changes::Unknown(why) => {
+                        writeln!(
+                            out,
+                            " \x1b[2mcould not check for changes: {}\x1b[0m\r\r",
+                            why
+                        )?;
+                    }
+                }
+            }
+        }
+
         if let Some((target, _)) = items.get(self.detail_cursor) {
             // Show the lines that `b` would actually write, not a fixed example — panes and
             // actions produce different `type` values, and a wrong example here would send
@@ -1040,7 +1113,11 @@ impl App {
             &[
                 (
                     "l / →",
-                    "what this plugin does — run its actions, or bind one to a key",
+                    "what this plugin does — its actions, and (if ↑) what changed since install",
+                ),
+                (
+                    "↑",
+                    "beside a commit: the repo moved since you installed; open with l",
                 ),
                 ("j / k", "down / up  (arrows and the wheel work too)"),
                 ("g / G", "first / last row"),
@@ -1213,12 +1290,13 @@ impl App {
             } else {
                 " "
             };
-            // The marker alone does not say what it means; on an otherwise-quiet row there is
-            // space to say it.
+            // Point at `l`, not `u`. The whole point of this feature is reading the change
+            // before applying it — telling the user to update straight away skips the review
+            // it exists to offer. `l` opens the details, which fetch and show what changed;
+            // `u` is the step after they have decided.
             let note = match (row.maybe_stale, row.status.note()) {
                 (true, n) if n.is_empty() => {
-                    "its repo has been pushed to since you installed — press u to update"
-                        .to_string()
+                    "updates available — press l to see what changed".to_string()
                 }
                 (_, n) => n,
             };


### PR DESCRIPTION
## What and why

The `↑` marker says a plugin's repository has been pushed to, but not whether the push is
worth pulling. So the only way to decide was to run `u` and see what happened, or leave the
terminal and open the repo on GitHub. This shows the change first.

Open a flagged plugin's details (`l`) and it lists the commit subjects between the installed
commit and the current default branch:

```
 13 new commit(s) since you installed  (press u to update)
   · Sync the spec kit with the upstream brainstorming resources
   · Release v0.24.1
   · Switch Linux release binaries from gnu to musl (#32)
   …
```

The list row now points at that, not straight at `u`:

```
✔ persiyanov/herdr-reviewr   bbeaac7b10fa↑ updates available — press l to see what changed
```

So the flow is read → decide → update, each step naming the next.

## Keeping it cheap

The tool's whole point is saving the user effort, so this must not add any:

- **Only fetches for a plugin the offline `↑` marker already flagged.** Opening an
  up-to-date plugin's details stays instant — going to the network on every `l` would make
  the common case (nothing changed) the slow one.
- **One request, on open, cached per row.** Reopening the same plugin does not re-hit the
  network. Nothing checks everything at once, so the unauthenticated 60/hour limit is ample.
- **`commits`, not `compare`.** The compare endpoint returns every file's diff — 550 KB for
  this repo. `commits` is 46 KB and carries what a decision needs: the subjects. Anyone who
  wants the full diff still has `ctrl+o` to open the repo.
- **Fails soft**, like the marketplace: offline or rate-limited shows "could not check for
  changes: …" and the pane carries on.

## Cost of the offline gate

The `↑` marker compares the cached `pushedAt` against the install time at day resolution, so
a push within a day of installing is not flagged yet, and its diff waits one more day. That
is the price of `l` never blocking on a plugin that is already current — the right trade for
a tool about not making the user wait.

## Tests

87 pass. The new module (`src/github.rs`) is tested against captured payloads rather than the
live API — the walk is where the off-by-one lives:

- commits newer than the installed one are listed; the installed commit itself is not "new"
- an abbreviated installed commit still matches (herdr may record it short)
- an install further back than one page reports a floor count, not a wrong total
- a rate-limit error object is reported, not parsed as commits
- only the subject line is kept; a commit body does not leak in
- garbage in is `Unknown`, never a panic

Verified end-to-end against a crafted-stale cache: a flagged plugin's details show the 13
real commits, and an up-to-date plugin fetches nothing.

## Checklist

- [x] `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` pass
- [x] New behaviour has a test
- [x] No new dependency (curl/wget, as elsewhere)
