### PR TITLE
Keep the list dotfiles-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,43 @@ normally one, so this also stops prune from removing the tool running it.
 
 Under-removing is recoverable. Uninstalling the wrong plugin is not.
 
+## Managing your list with dotfiles
+
+Your `plugins.list` is the whole declaration — one `owner/repo` per line — and `plugins.lock`
+is the exact commits it resolved to. Both are plain text, both belong in a dotfiles repo, and
+together they are all another machine needs.
+
+Point herdr-lazy at a file in your repo with `HERDR_LAZY_LIST`:
+
+```sh
+# in your shell profile, or a herdr-lazy env
+export HERDR_LAZY_LIST="$HOME/dotfiles/herdr/plugins.list"
+```
+
+The lock is written next to it (`plugins.lock`), so both live in your repo. The marketplace
+cache is kept out of the way in `$XDG_CACHE_HOME/herdr-lazy/` (or `~/.cache/herdr-lazy/`), so
+nothing you did not choose ends up staged.
+
+On a new machine:
+
+```sh
+git clone …/dotfiles && export HERDR_LAZY_LIST="$HOME/dotfiles/herdr/plugins.list"
+herdr-lazy restore     # the exact commits from plugins.lock
+# or: herdr-lazy sync   # the latest of whatever the list asks for
+```
+
+`restore` reproduces the lock commit-for-commit; `sync` installs the latest each entry
+resolves to. Commit both files after a change and the next machine is one command behind.
+
+### Nix
+
+herdr's own flake packages the CLI; plugins are herdr-lazy's job, not the flake's. There is no
+home-manager module yet — if that is something you would use, open an issue. In the meantime a
+Nix user can generate `plugins.list` from their config and set `HERDR_LAZY_LIST` to it, which
+keeps the plugin set declarative without herdr-lazy needing to know about Nix at all. Note that
+`auto-sync` installs on herdr startup, a side effect a purist may want off (it is off by
+default); `restore` in an activation script is the more Nix-shaped fit.
+
 ## The default bundle
 
 A distro is an opinion, so here is the reasoning rather than just the list. Two criteria,

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,17 +107,34 @@ fn legacy_config_dir() -> PathBuf {
     PathBuf::from(home).join(".config").join("herdr-lazy")
 }
 
+/// The declared plugin list.
+///
+/// `HERDR_LAZY_LIST` moves it anywhere — the point being that a dotfiles user keeps it in
+/// their repo and points here, instead of the file living buried in herdr's plugin config
+/// dir mixed in with a cache they do not want to commit. Unset, it stays exactly where it
+/// always was, so nothing changes for anyone not asking for this.
 pub(crate) fn bundle_path() -> PathBuf {
+    if let Ok(p) = env::var("HERDR_LAZY_LIST") {
+        if !p.is_empty() {
+            return PathBuf::from(p);
+        }
+    }
     config_dir().join("plugins.list")
 }
 
-/// The lock sits beside the bundle, not in a state dir.
+/// The lock sits beside the list, wherever the list is.
 ///
 /// It is generated, but it is also the file you copy to another machine to reproduce a
-/// setup — the same reasoning that puts Cargo.lock next to Cargo.toml. Keeping both in one
-/// directory also means there is exactly one location to reason about.
+/// setup — the same reasoning that puts Cargo.lock next to Cargo.toml. So a dotfiles user who
+/// moved their list into their repo gets the lock there too, both git-managed together.
 fn lock_path() -> PathBuf {
-    config_dir().join("plugins.lock")
+    lock_beside(&bundle_path())
+}
+
+/// The lock that belongs next to a given list. Split out so the "beside the list" rule can be
+/// tested without touching the environment the real path reads from.
+fn lock_beside(list: &Path) -> PathBuf {
+    list.with_file_name("plugins.lock")
 }
 
 fn ensure_parent(p: &Path) -> io::Result<()> {
@@ -160,6 +177,12 @@ pub(crate) fn desired_plugins() -> Vec<String> {
 /// the legacy file is left alone and nothing is overwritten. Copy rather than move, so a
 /// mistake here cannot lose the user's list.
 fn migrate_legacy_bundle() {
+    // When the location was chosen explicitly, do not auto-populate it. That path is likely a
+    // dotfiles repo, and silently writing a legacy list into it is not ours to do — `init` or
+    // `add` will, when the user asks.
+    if env::var("HERDR_LAZY_LIST").is_ok_and(|v| !v.is_empty()) {
+        return;
+    }
     let current = bundle_path();
     if current.exists() {
         return;
@@ -1921,6 +1944,20 @@ command = "something.else"
         );
         unsafe { env::remove_var("HERDR_SOCKET_PATH") };
         assert_eq!(herdr_config_path(), None, "no socket, no guessing");
+    }
+
+    #[test]
+    fn the_lock_always_sits_beside_the_list() {
+        // Wherever the list is moved, the lock follows into the same directory, so a dotfiles
+        // user gets both in their repo rather than the lock stranded in herdr's config dir.
+        assert_eq!(
+            lock_beside(Path::new("/home/me/dotfiles/herdr/plugins.list")),
+            Path::new("/home/me/dotfiles/herdr/plugins.lock")
+        );
+        assert_eq!(
+            lock_beside(Path::new("plugins.list")),
+            Path::new("plugins.lock")
+        );
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -131,8 +131,22 @@ pub(crate) fn today_days() -> i64 {
         .unwrap_or(0)
 }
 
+/// Where the marketplace cache lives.
+///
+/// A cache, not configuration — so it goes in the cache directory, not beside the list. This
+/// matters once `HERDR_LAZY_LIST` points the list into a dotfiles repo: a 140 KB marketplace
+/// dump appearing there on first browse, needing a `.gitignore` entry, is exactly the kind of
+/// mess this separation avoids. `XDG_CACHE_HOME` when set, else `~/.cache`.
 fn cache_path() -> PathBuf {
-    crate::config_dir().join("marketplace.json")
+    let base = std::env::var("XDG_CACHE_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".cache")
+        });
+    base.join("herdr-lazy").join("marketplace.json")
 }
 
 fn cache_age_seconds() -> Option<u64> {


### PR DESCRIPTION
## What and why

`plugins.list` and `plugins.lock` are the whole point of this tool — a declared set and the
commits it resolved to, both plain text, both what another machine needs. That is exactly what
a dotfiles user keeps in git. But until now the list lived buried in herdr's plugin config
dir, mixed in with a 140 KB marketplace cache, with no way to move it.

This makes the split by purpose:

- **`plugins.list` + `plugins.lock`** — the declaration and the reproducibility record. Now
  relocatable with `HERDR_LAZY_LIST`, so they live in your repo.
- **`marketplace.json`** — a cache. Now in `$XDG_CACHE_HOME/herdr-lazy/` (or `~/.cache/…`), so
  it never lands in a dotfiles repo and needs no `.gitignore` entry.
- **`auto-sync` marker** — machine-local state. Deliberately *not* moved: you may want
  auto-sync on your laptop and off on a server.

## Behaviour

```sh
export HERDR_LAZY_LIST="$HOME/dotfiles/herdr/plugins.list"
```

- The lock is written beside the list (`plugins.lock`), so both are git-managed together.
- On a new machine: clone, set the var, `herdr-lazy restore` (exact commits) or `sync`
  (latest). This workflow already worked; it was just undiscoverable and the paths were
  awkward. Most of this PR is the README section that names it.
- **Unset, nothing changes.** The list stays in herdr's config dir exactly as before, so no
  existing install moves.
- With the var set, the legacy auto-migration is skipped: that path is likely a git repo, and
  silently writing a legacy list into it is not ours to do — `init`/`add` populate it when
  asked.

## Nix

Documented, not built. herdr's own flake packages the CLI; plugins are this tool's job. There
is no home-manager module — flagged as "open an issue if you want it" rather than committing to
Nix code in this repo. A Nix user can generate `plugins.list` and set `HERDR_LAZY_LIST`, with a
note that `restore` in an activation script fits Nix better than the startup `auto-sync` side
effect.

## Tests

88 pass. The env-var resolution is verified end-to-end with the real binary rather than in a
unit test — env vars are process-global and these tests run in parallel, so a live check is
both safer and stronger. The pure part (the lock always sits beside the list, wherever that
is) is unit-tested.

Verified: `HERDR_LAZY_LIST` puts list and lock in the target dir, the cache goes to
`XDG_CACHE_HOME` and not there, and with no env var the paths are unchanged.

## Checklist

- [x] `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` pass
- [x] New behaviour has a test (pure part) + live verification (env part)
- [x] No new dependency
