### PR TITLE
Show each plugin's description in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ machine. herdr-lazy adds both.
   `i`/`u`/`x`/`r` as in lazy.nvim. Tick rows with space or a click to act on several at
   once, or act on just the row under the cursor when nothing is ticked. `?` shows the full
   keymap; the mouse scrolls and ticks.
+- **A list that tells you what each plugin is.** Every installed row shows its own one-line
+  description, so you can tell what you have and spot two plugins that do the same thing
+  without opening each one.
 - **A way to find out what you just installed.** Press `l` on any plugin to see what it
   does, which actions it offers, which panes it can open, and what makes it run on its own
   — then run an action right there.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -119,6 +119,30 @@ struct Row {
     detail: Option<PluginDetail>,
 }
 
+impl Row {
+    /// What the trailing column shows: a status note when there is one, otherwise the
+    /// plugin's own description.
+    ///
+    /// The order is the whole design. A status note ("not installed", "updates available")
+    /// is about what to *do*; the description is about what the plugin *is*. When there is
+    /// something to do, that wins — you need to know a plugin is missing before you care what
+    /// it is for. When the row is healthy the description fills the space that used to be
+    /// blank, which is where "the name alone doesn't tell me what it does" came from.
+    fn trailing_text(&self) -> String {
+        if self.maybe_stale && self.status.note().is_empty() {
+            return "updates available — press l to see what changed".to_string();
+        }
+        let note = self.status.note();
+        if !note.is_empty() {
+            return note;
+        }
+        self.detail
+            .as_ref()
+            .map(|d| d.description.clone())
+            .unwrap_or_default()
+    }
+}
+
 /// The manifest facts worth showing a user who just installed seven plugins at once.
 #[derive(Debug, Clone, Default)]
 struct PluginDetail {
@@ -1294,12 +1318,10 @@ impl App {
             // before applying it — telling the user to update straight away skips the review
             // it exists to offer. `l` opens the details, which fetch and show what changed;
             // `u` is the step after they have decided.
-            let note = match (row.maybe_stale, row.status.note()) {
-                (true, n) if n.is_empty() => {
-                    "updates available — press l to see what changed".to_string()
-                }
-                (_, n) => n,
-            };
+            let note = row.trailing_text();
+            // The trailing text gets whatever width is left, so a narrow pane truncates the
+            // description rather than wrapping or pushing the row off-screen.
+            let trailing_width = (width as usize).saturating_sub(66);
             writeln!(
                 out,
                 "{} {}{}{}\x1b[0m {:<44} \x1b[2m{:<12}\x1b[0m{} {}\x1b[0m\r",
@@ -1313,7 +1335,7 @@ impl App {
                 if note.is_empty() {
                     String::new()
                 } else {
-                    format!("\x1b[2m{}\x1b[0m", note)
+                    format!("\x1b[2m{}\x1b[0m", truncate(&note, trailing_width))
                 },
             )?;
         }
@@ -2238,6 +2260,47 @@ mod tests {
         let r = rows_with_updates(&[], &installed, &market);
         assert_eq!(r.len(), 1);
         assert!(r[0].maybe_stale);
+    }
+
+    /// The description fills the trailing column only when the row is healthy — a status note
+    /// or an update hint always wins, because what to do beats what the plugin is.
+    #[test]
+    fn a_healthy_row_shows_its_description() {
+        let mut p = github("owner", "thing", SHA, true);
+        p.description = "does a useful thing".into();
+        let r = rows(&[Spec::parse("owner/thing")], &[p]);
+        assert_eq!(r[0].status, Status::Ok);
+        assert_eq!(r[0].trailing_text(), "does a useful thing");
+    }
+
+    #[test]
+    fn a_status_note_wins_over_the_description() {
+        // Missing: not installed, so there is no description anyway, and the note must show.
+        let r = rows(&[Spec::parse("owner/absent")], &[]);
+        assert_eq!(r[0].status, Status::Missing);
+        assert!(r[0].trailing_text().contains("not installed"));
+    }
+
+    #[test]
+    fn the_update_hint_wins_over_the_description() {
+        let mut p = github("owner", "thing", SHA, true);
+        p.description = "does a thing".into();
+        p.installed_unix_ms = Some(20_000 * 86_400_000);
+        let market = vec![crate::registry::Entry {
+            full_name: "owner/thing".into(),
+            pushed_at: "2024-10-05T00:00:00Z".into(),
+            ..Default::default()
+        }];
+        let r = rows_with_updates(&[Spec::parse("owner/thing")], &[p], &market);
+        assert!(r[0].maybe_stale);
+        assert!(r[0].trailing_text().contains("press l"));
+    }
+
+    #[test]
+    fn a_plugin_with_no_description_trails_nothing() {
+        let p = github("owner", "bare", SHA, true); // description defaults empty
+        let r = rows(&[Spec::parse("owner/bare")], &[p]);
+        assert_eq!(r[0].trailing_text(), "");
     }
 
     #[test]


### PR DESCRIPTION
## What and why

The list showed a name and a commit, and a healthy row ended blank. So `herdr-hail` was just
a name — you could not tell it was a Slack/Discord bridge, or that it overlapped another
notifier you had, without opening each plugin's details one at a time.

Every installed row now shows its own one-line description in the space that used to be empty:

```
✔ natori-hrj/herdr-hail     Two-way Slack & Discord bridge — pinged when an agent blocks…
✔ natori-hrj/herdr-triage   Ranks your agents by who needs you most…
✔ persiyanov/herdr-reviewr  Review agent-written diffs beside the chat…
```

That answers both halves of the ask it came from: you can tell what a plugin is, and with
descriptions side by side you can spot two that do the same job.

## Why descriptions, not categories

The obvious alternative was grouping by category. Checked against the marketplace index:
topics are unreliable for this — 2 of the owner's own 9 plugins carry no usable topic, and the
ones that exist mix purpose (`triage`) with tech tags (`rust`, `tui`). Auto-categorising would
drop plugins into "other" and mis-shelve others.

The description is the honest signal instead: every plugin has one, it comes from
`plugin list --json` (so the list stays offline-capable, unlike the update markers), and
reading a column of them lets a human do the grouping a topic map cannot.

## Behaviour

- A **status note wins** over the description — "not installed", "updates available — press l"
  — because what to *do* with a row beats what it *is*. The description fills the trailing
  column only on a healthy row.
- A plugin with no description trails nothing (no filler).
- The trailing text takes the width that is left and truncates with `…`, so a narrow pane
  never wraps a row or pushes the commit column off screen.

## Tests

92 pass. The trailing-text priority is extracted to `Row::trailing_text` and tested directly:
a healthy row shows its description, a status note wins, the update hint wins, and an empty
description trails nothing. Verified in a real pane at 130 and 80 columns.

## Checklist

- [x] `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` pass
- [x] New behaviour has a test
- [x] No new dependency
