### PR TITLE
build: switch Linux targets from gnu to musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macos-latest
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # `--component` takes one value; a bare second name is parsed as a toolchain.
-      - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+      - run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+          rustup target add ${{ matrix.target }}
+      - if: contains(matrix.target, 'musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
       - run: cargo fmt --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test --locked
+      - run: cargo clippy --all-targets --target ${{ matrix.target }} -- -D warnings
+      - run: cargo test --locked --target ${{ matrix.target }}
 
   # The declared MSRV is a promise; check it rather than letting it rot.
   msrv:
@@ -33,4 +41,6 @@ jobs:
           set -euo pipefail
           msrv=$(sed -n 's/^rust-version *= *"\([^"]*\)".*/\1/p' Cargo.toml | head -1)
           rustup toolchain install "$msrv" --profile minimal
-          cargo "+$msrv" test --locked
+          rustup target add x86_64-unknown-linux-musl --toolchain "$msrv"
+          sudo apt-get update && sudo apt-get install -y musl-tools
+          cargo "+$msrv" test --locked --target x86_64-unknown-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             native: false
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             native: true
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
             native: true
     runs-on: ${{ matrix.os }}
@@ -80,6 +80,10 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal
           rustup target add ${{ matrix.target }}
+
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - if: matrix.native
         run: cargo test --locked --target ${{ matrix.target }}

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -62,7 +62,7 @@ VERSION=$(sed -n 's/^version *= *"\([^"]*\)".*/\1/p' herdr-plugin.toml | head -1
 
 case "$(uname -s)" in
     Darwin) OS="apple-darwin" ;;
-    Linux)  OS="unknown-linux-gnu" ;;
+    Linux)  OS="unknown-linux-musl" ;;
     *)      log "unrecognised OS $(uname -s)"; build_from_source ;;
 esac
 


### PR DESCRIPTION
## What and why

The prebuilt Linux binaries target `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`,
which dynamically link glibc. Environments with an older glibc — Amazon Linux 2023, Alpine,
older Ubuntu containers — cannot run them, and the install silently falls back to compiling
from source (or fails outright if Rust is not installed).

herdr itself ships musl binaries. This switches the Linux targets to match:
`x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`. musl produces a fully static
binary that runs on any Linux regardless of the system libc.

Three files, one-line-each kind of change:

- `scripts/fetch-or-build.sh` — look for the musl triple instead of gnu
- `.github/workflows/release.yml` — build musl targets, install `musl-tools`
- `.github/workflows/ci.yml` — test against musl on Linux

## Checklist

- [x] `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` pass
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [x] No new dependency