### PR TITLE
feat: add opt-in extras (init --extras)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,35 @@ Self-submissions are fine and are judged the same way. Note that the current set
 plugins by this project's author, which is a fair thing to point at — the criteria above are
 the answer, and they apply to those entries too.
 
+## Adding a plugin to the extras
+
+Extras are opt-in categories — `init --extras worktree` — for capabilities the default set
+deliberately leaves out because the right answer depends on you: which worktree tool, which
+notifier. An extra is proposed by a pull request and judged against a checklist, the same way
+a default-set entry is. It differs from the default-set bar in one direction only: because an
+extra is opt-in, it is allowed to be an opinionated, personal choice.
+
+An extra earns its place when:
+
+1. **It installs cleanly.** The same rule as the default set, and just as non-negotiable — a
+   prebuilt binary or no build step. An install that fails under herdr's build PATH is not
+   made acceptable by being opt-in.
+2. **It is one coherent capability, not a category dump.** The unit is `worktrunk`, not "all
+   the worktree plugins". Naming an extra after a single job is what keeps `--extras worktree`
+   from installing three things that do the same thing.
+3. **Within a category, overlapping plugins are alternatives, not a stack.** If two plugins
+   both manage worktrees, they are two extras you choose between; enabling one must not pull
+   in the other. This is the default set's "swap, not add", applied to the menu.
+4. **Someone actually uses it, and it does what its description says.** The person proposing
+   it is the obvious someone — "I built this and use it daily" is a good way to open the PR.
+5. **Any external setup is stated up front.** If it needs a Slack app, an account, a running
+   service, or a CLI installed separately, the extra's one-line description says so. The point
+   of opting in is that the choice is informed.
+
+Self-submissions are welcome and held to exactly this list, and so are the maintainer's own
+plugins: being written by the author is not a reason to include something here, the same way
+it is not for the default set.
+
 ## Reporting a bug
 
 The useful ones tend to include:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ herdr-lazy list          # show what the list asks for
 herdr-lazy sync          # install what is missing
 herdr-lazy update        # move unpinned entries to their latest commit
 herdr-lazy sync --prune  # also uninstall anything not in the list
+
+herdr-lazy extras                    # list the opt-in extras
+herdr-lazy init --extras worktrunk   # defaults plus a chosen extra
 ```
 
 `sync` and `update` take plugin names to work on just those:
@@ -105,7 +108,8 @@ herdr-lazy update smarzban/herdr-file-viewer
 
 | command | what it does |
 |---|---|
-| `init [--force]` | write the curated default bundle |
+| `init [--force] [--extras <id,…>]` | write the curated default bundle, plus any opt-in extras |
+| `extras` | list the opt-in extras you can pass to `init --extras` |
 | `list` | show the desired plugin set |
 | `install [<repo>…]` | install what is missing, restore drifted pins |
 | `sync [<repo>…] [--prune]` | the same, plus `--prune` to uninstall what is not listed |
@@ -354,13 +358,10 @@ a file pane is a worse default than one.
 | [persiyanov/herdr-reviewr](https://github.com/persiyanov/herdr-reviewr) | review an agent's diff line by line and send comments back to it |
 | [razajamil/herdr-plugin-workspace-manager](https://github.com/razajamil/herdr-plugin-workspace-manager) | per-workspace tab/pane layouts, applied automatically |
 | [natori-hrj/herdr-triage](https://github.com/natori-hrj/herdr-triage) | ranks agents by who needs you most |
-| [natori-hrj/herdr-green](https://github.com/natori-hrj/herdr-green) | runs a project's tests when its agent finishes |
-| [natori-hrj/herdr-standup](https://github.com/natori-hrj/herdr-standup) | digest of what every agent actually changed |
 
-The last three are by this project's author. They are here because running several agents
-at once creates a problem the ecosystem does not otherwise address — knowing which one to
-look at, whether its work is sound, and what it did — not because of who wrote them. If
-that is not your problem, remove them.
+The last one is by this project's author. It is here because running several agents at once
+creates a problem the ecosystem does not otherwise address — knowing which one to look at —
+not because of who wrote it. If that is not your problem, remove it.
 
 A third criterion showed up during testing: it has to actually install. herdr runs plugin
 builds with a minimal PATH that excludes `~/.cargo/bin`, so a plugin whose build is a bare
@@ -378,6 +379,27 @@ depends on where you want to be pinged — not a decision a default set should m
 
 None of this is load-bearing: `init` just writes these lines into `plugins.list`. Edit it,
 or skip `init` and build your own with `add`.
+
+## Extras
+
+The default bundle stays out of choices that depend on you — which worktree tool, which
+notifier. Extras are how you opt into those, by name:
+
+```sh
+herdr-lazy extras                    # see what is on offer, grouped by category
+herdr-lazy init --extras worktrunk   # curated defaults, plus the worktrunk workflow
+```
+
+An extra is one coherent capability, not a category dump. Where two plugins do the same job
+they are two extras you choose between — `--extras` never stacks them, the same way the
+default set swaps rather than adds. Each extra's description names any external setup it needs
+(a CLI to install, a service to configure) so opting in is an informed choice.
+
+Extras are plain `owner/repo` lists under [`extras/`](extras/), embedded at build time, so
+listing one never touches the network. Adding an extra is a small, reviewed pull request —
+drop a file in `extras/` and add a line to the registry. The bar it clears is in
+[CONTRIBUTING.md](CONTRIBUTING.md#adding-a-plugin-to-the-extras), and it is the same bar for a
+contributor's plugin and the author's.
 
 ## Roadmap
 

--- a/extras/pluck.list
+++ b/extras/pluck.list
@@ -1,0 +1,3 @@
+# category: navigation
+# Grab URLs, commit SHAs, and file paths out of a pane by keyboard — no mouse, no reaching.
+rmarganti/herdr-pluck

--- a/extras/worktrunk.list
+++ b/extras/worktrunk.list
@@ -1,0 +1,3 @@
+# category: worktree
+# Switch git worktrees from a picker, with per-worktree setup. Needs the `worktrunk` CLI and fzf.
+devashish2203/herdr-worktrunk

--- a/src/extras.rs
+++ b/src/extras.rs
@@ -1,0 +1,129 @@
+//! Extras — opt-in, per-capability plugin picks, grouped by category.
+//!
+//! Where the default bundle (`init`) is one curated baseline, an extra is a single capability
+//! you ask for by name — `init --extras worktrunk` — for the jobs the default set deliberately
+//! leaves to you (which worktree tool, which notifier). Each extra is one coherent choice, not
+//! a category dump: two plugins that do the same job are two extras you pick between, never a
+//! stack. See CONTRIBUTING.md for the bar a new extra clears.
+//!
+//! Definitions are plain `owner/repo` lists embedded at build time, so listing or resolving an
+//! extra never touches the network. Adding one is a data change: drop a file in `extras/` and
+//! add a line to `REGISTRY` — the file is the definition, the line makes it visible.
+
+/// A named, opt-in capability: one entry in the extras menu.
+pub(crate) struct Extra {
+    pub id: &'static str,
+    pub category: String,
+    pub description: String,
+    pub plugins: Vec<String>,
+}
+
+/// `(id, embedded definition)`. Add an extra by dropping `extras/<id>.list` and a line here.
+const REGISTRY: &[(&str, &str)] = &[
+    ("pluck", include_str!("../extras/pluck.list")),
+    ("worktrunk", include_str!("../extras/worktrunk.list")),
+];
+
+/// All extras, in registry order, parsed from their embedded definitions.
+pub(crate) fn all() -> Vec<Extra> {
+    REGISTRY.iter().map(|(id, body)| parse(id, body)).collect()
+}
+
+/// Look up one extra by id.
+pub(crate) fn find(id: &str) -> Option<Extra> {
+    REGISTRY
+        .iter()
+        .find(|(eid, _)| *eid == id)
+        .map(|(eid, body)| parse(eid, body))
+}
+
+/// Parse an extra definition:
+///   `# category: <name>`  — the grouping label (defaults to "other" if absent)
+///   `# <text>`            — the one-line description (first comment that is not `category:`)
+///   `owner/repo`          — one plugin per line; usually one, occasionally a non-overlapping pair
+fn parse(id: &'static str, body: &str) -> Extra {
+    let mut category = String::new();
+    let mut description = String::new();
+    let mut plugins = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(comment) = line.strip_prefix('#') {
+            let comment = comment.trim();
+            if let Some(cat) = comment.strip_prefix("category:") {
+                category = cat.trim().to_string();
+            } else if description.is_empty() {
+                description = comment.to_string();
+            }
+        } else {
+            plugins.push(line.to_string());
+        }
+    }
+    Extra {
+        id,
+        category: if category.is_empty() {
+            "other".to_string()
+        } else {
+            category
+        },
+        description,
+        plugins,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_category_description_and_plugins() {
+        let e = parse(
+            "x",
+            "# category: worktree\n# does a thing\nowner/repo\nowner/two\n",
+        );
+        assert_eq!(e.category, "worktree");
+        assert_eq!(e.description, "does a thing");
+        assert_eq!(
+            e.plugins,
+            vec!["owner/repo".to_string(), "owner/two".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_missing_category_defaults_to_other() {
+        let e = parse("x", "# just a description\nowner/repo\n");
+        assert_eq!(e.category, "other");
+        assert_eq!(e.description, "just a description");
+    }
+
+    /// The `category:` line must not be consumed as the description.
+    #[test]
+    fn the_category_line_is_not_mistaken_for_the_description() {
+        let e = parse("x", "# category: nav\n# real description\na/b\n");
+        assert_eq!(e.description, "real description");
+    }
+
+    #[test]
+    fn find_returns_none_for_an_unknown_id() {
+        assert!(find("definitely-not-an-extra").is_none());
+    }
+
+    /// Every embedded seed file must parse into a usable extra — this fails the test step if a
+    /// data file is malformed or a `REGISTRY` line points at nothing.
+    #[test]
+    fn every_registered_extra_is_well_formed() {
+        let all = all();
+        assert!(!all.is_empty());
+        for e in &all {
+            assert!(!e.id.is_empty());
+            assert!(!e.category.is_empty(), "{} has no category", e.id);
+            assert!(!e.description.is_empty(), "{} has no description", e.id);
+            assert!(!e.plugins.is_empty(), "{} lists no plugins", e.id);
+            for p in &e.plugins {
+                assert!(p.contains('/'), "{}: '{}' is not owner/repo", e.id, p);
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@
 //! only its name can be compared), and `--prune` acts on Strong only.
 
 mod browse;
+mod extras;
 mod github;
 mod json;
 mod registry;
@@ -61,10 +62,8 @@ const DEFAULT_BUNDLE: &[&str] = &[
     "smarzban/herdr-file-viewer",               // git-aware read-only file pane
     "persiyanov/herdr-reviewr",                 // comment on an agent's diff, send it back
     "razajamil/herdr-plugin-workspace-manager", // per-workspace tab/pane layouts; no build step
-    // Gaps nothing else covers: keeping a human oriented across several running agents.
-    "natori-hrj/herdr-triage",  // which agent needs you most
-    "natori-hrj/herdr-green",   // did its tests pass when it finished
-    "natori-hrj/herdr-standup", // what all your agents actually changed
+    // Gap nothing else covers: keeping a human oriented across several running agents.
+    "natori-hrj/herdr-triage", // which agent needs you most
 ];
 
 fn herdr_bin() -> String {
@@ -574,8 +573,32 @@ fn cmd_probe() -> io::Result<()> {
     Ok(())
 }
 
-/// Write the curated default bundle (the distro layer).
-fn cmd_init(force: bool) -> io::Result<()> {
+/// Parse `--extras a,b` or `--extras=a,b` (repeatable) into a list of extra ids.
+fn extras_arg(rest: &[&str]) -> Vec<String> {
+    let split = |v: &str| {
+        v.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+    };
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < rest.len() {
+        if let Some(v) = rest[i].strip_prefix("--extras=") {
+            out.extend(split(v));
+        } else if rest[i] == "--extras" {
+            if let Some(v) = rest.get(i + 1) {
+                out.extend(split(v));
+                i += 1;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Write the curated default bundle (the distro layer), plus any opt-in extras.
+fn cmd_init(force: bool, extra_ids: &[String]) -> io::Result<()> {
     let p = bundle_path();
     if p.exists() && !force {
         println!(
@@ -584,6 +607,24 @@ fn cmd_init(force: bool) -> io::Result<()> {
         );
         return Ok(());
     }
+
+    // Resolve requested extras before writing anything, so an unknown id fails fast rather than
+    // leaving a half-written bundle.
+    let mut chosen = Vec::new();
+    let mut unknown = Vec::new();
+    for id in extra_ids {
+        match extras::find(id) {
+            Some(e) => chosen.push(e),
+            None => unknown.push(id.as_str()),
+        }
+    }
+    if !unknown.is_empty() {
+        let known: Vec<&str> = extras::all().iter().map(|e| e.id).collect();
+        eprintln!("unknown extra(s): {}", unknown.join(", "));
+        eprintln!("available: {} (see `herdr-lazy extras`)", known.join(", "));
+        return Ok(());
+    }
+
     ensure_parent(&p)?;
     let mut body = String::new();
     body.push_str("# herdr-lazy bundle — your declarative plugin set.\n");
@@ -593,9 +634,61 @@ fn cmd_init(force: bool) -> io::Result<()> {
         body.push_str(d);
         body.push('\n');
     }
+
+    // Each extra's plugins go under a comment naming it, skipping anything the defaults already
+    // cover so a plugin is never listed twice.
+    let mut seen: Vec<String> = DEFAULT_BUNDLE.iter().map(|s| s.to_string()).collect();
+    for e in &chosen {
+        let fresh: Vec<&String> = e.plugins.iter().filter(|pl| !seen.contains(pl)).collect();
+        if fresh.is_empty() {
+            continue;
+        }
+        body.push_str("\n# extra: ");
+        body.push_str(e.id);
+        body.push_str(" — ");
+        body.push_str(&e.description);
+        body.push('\n');
+        for pl in fresh {
+            body.push_str(pl);
+            body.push('\n');
+            seen.push(pl.clone());
+        }
+    }
+
     fs::write(&p, body)?;
     println!("wrote curated default bundle -> {}", p.display());
+    if !chosen.is_empty() {
+        println!("with extras:");
+        for e in &chosen {
+            println!("  {} — {}", e.id, e.description);
+        }
+    }
     println!("edit it if you like, then run `herdr-lazy sync`.");
+    Ok(())
+}
+
+/// List the opt-in extras, grouped by category.
+fn cmd_extras() -> io::Result<()> {
+    let all = extras::all();
+    if all.is_empty() {
+        println!("no extras are defined.");
+        return Ok(());
+    }
+    println!("opt-in extras — add with `herdr-lazy init --extras <id,…>`:\n");
+    // Categories in first-seen order; a plain Vec is enough for a handful of entries.
+    let mut categories: Vec<String> = Vec::new();
+    for e in &all {
+        if !categories.iter().any(|c| c == &e.category) {
+            categories.push(e.category.clone());
+        }
+    }
+    for cat in &categories {
+        println!("{}:", cat);
+        for e in all.iter().filter(|e| &e.category == cat) {
+            println!("  {:<12} {}", e.id, e.description);
+        }
+        println!();
+    }
     Ok(())
 }
 
@@ -1513,7 +1606,8 @@ fn print_help() {
     println!("herdr-lazy — be lazy: a curated plugin distro & manager for herdr\n");
     println!("USAGE: herdr-lazy <command>\n");
     println!("  probe             verify the plugin <-> herdr CLI bridge (run this first)");
-    println!("  init [--force]    write the curated default bundle (the distro layer)");
+    println!("  init [--force] [--extras <id,…>]  write the default bundle (the distro layer)");
+    println!("  extras            list the opt-in extras you can pass to `init --extras`");
     println!("  list              show desired plugins");
     println!("  install [<repo>…] install what is missing, restore drifted pins");
     println!("  sync [--prune]    the same, plus --prune to remove what is not listed");
@@ -1535,7 +1629,8 @@ fn main() {
         "probe" => cmd_probe(),
         "startup" => cmd_startup(),
         "auto-sync" => cmd_auto_sync(rest.first().copied()),
-        "init" => cmd_init(rest.contains(&"--force")),
+        "init" => cmd_init(rest.contains(&"--force"), &extras_arg(&rest)),
+        "extras" => cmd_extras(),
         "list" => cmd_list(),
         // `install` is what people look for; `sync` is what the operation is. Both, rather
         // than choosing and leaving the other as a dead end.


### PR DESCRIPTION
## Summary

Adds LazyVim-style **opt-in extras** to herdr-lazy. The set `init` writes stays one curated
baseline; choices that depend on you — which worktree tool, which notifier — are now opted
into by name with `--extras <id>`. Also drops two plugins the author does not actually use
from the default set, so the "included things are things someone actually uses" bar applies to
the defaults too, not just to contributions.

## What changed

- `herdr-lazy extras` — list the available extras, grouped by category.
- `herdr-lazy init --extras worktrunk,pluck` — write the curated defaults plus the chosen
  extras (skips anything the defaults already cover; an unknown id writes nothing and fails
  fast rather than leaving a half-written bundle).
- Extra definitions are `extras/*.list` files (the existing list format) embedded with
  `include_str!`, so listing or resolving one never touches the network.
- Contributing an extra is a small PR — drop a file in `extras/` and add a registry line. The
  acceptance criteria are spelled out in CONTRIBUTING.md.
- Removed herdr-green and herdr-standup from the default set (the author does not use them);
  herdr-triage stays. The bar is identical for the author's plugins, a contributor's, and a
  self-submission.
- README: added an Extras section, usage, and command-table entries.

## Design decisions

- **Bundling and browsing are different jobs**: curate for install (quality), keyword-match for
  browse (coverage). #14's unsettled "how to define a category" came from conflating the two;
  only the install/bundling side ships here.
- **An extra is one coherent capability, not a category dump.** Overlapping plugins are offered
  as alternatives you choose between — `--extras` never stacks them.
- **One bar, no author privilege.**

Closes #14 (the browse-side keyword filter is left as a separate follow-up issue).

## How to test

- [x] `cargo test` (97 passed), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`.
- [x] Verified `extras`, `init --extras worktrunk,pluck` merging, and unknown-id fail-fast on a
  throwaway bundle.
- [x] `every_registered_extra_is_well_formed` validates the seed `.list` files in CI.

## Checklist

- [x] Added/updated tests (5 for the extras parser + seed validation).
- [x] Updated docs (README, CONTRIBUTING).
- [x] No breaking change (two plugins leave the default set, but existing bundles are not rewritten).