### PR TITLE
Lead the README with the one file the tool is about

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,21 @@ A declarative plugin **manager** and curated **distro** for [herdr](https://herd
 
 herdr installs plugins one imperative command at a time. There is no way to declare the
 set you want, and no lockfile — so a working setup cannot be reproduced on another
-machine. herdr-lazy adds both.
+machine.
+
+herdr-lazy replaces that with one file you own. `plugins.list` is a plain list of
+`owner/repo` lines: readable, editable by hand, keepable in git, copyable to another
+machine. Everything the tool does is a way to reach that file — `init` writes a good
+starting one, extras append curated bundles, `add` and `remove` edit it, the manage pane
+edits it on single keys — and `sync` makes your machine match it, at the exact commits the
+lockfile records.
 
 ![herdr-lazy: the manage pane, searching the marketplace and adding a plugin](docs/demo.gif)
 
 ## What it gives you
 
-- **A declarative plugin list.** One `owner/repo` per line. `sync` converges your
-  machine to it — installing what is missing, and (with `--prune`) removing the rest.
+- **A declarative plugin list.** `sync` converges your machine to it — installing what is
+  missing, and (with `--prune`) removing the rest.
 - **A real lockfile.** Entries pin to a commit, and the lock records the commit herdr
   actually checked out. Copy the lock to another machine, `sync`, and you get the same
   plugins at the same commits.


### PR DESCRIPTION
## Summary

The README opened by describing what herdr lacks and saying herdr-lazy "adds both". That is
accurate, but it frames the project as two features bolted onto herdr, which makes every later
section read as an unrelated list: a list, a lockfile, a pane, extras, marketplace search.

They are not unrelated. They are all entry points to the same artifact — `plugins.list`. This
rewrites the opener to say so, so the rest of the README reads as one idea rather than a
feature inventory.

## Changes

- Added a paragraph after the problem statement: the file is the thing you own, and `init`,
  extras, `add`/`remove`, and the manage pane are all ways to reach it, with `sync` converging
  the machine to whatever it says.
- Dropped `One owner/repo per line.` from the first bullet, now that the paragraph above says it.

No behaviour change; documentation only.

## Notes

The wording deliberately avoids abstract nouns ("ownable", "shareable") and shows the same
three properties concretely instead — `editable by hand`, `copyable to another machine`, `at
the exact commits`. It also names one distro-side entry point (`init`, extras) and one
manager-side entry point (`add`/`remove`, the pane) in the same sentence, so the two layers are
shown converging on one file rather than being announced as an architecture.

This is also the framing #20 and #21 are designed against, so the opener and those issues now
tell the same story.
