### PR TITLE
Windows: fix the build, and make the actions and pane spawnable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: macos-latest
             target: aarch64-apple-darwin
+          # Windows is declared in `platforms`, so it is built here rather than taken on
+          # trust. Without the cfg(windows) crossterm entry in Cargo.toml this job is what
+          # fails: the crate stops the build with compile_error! when its `windows`
+          # feature is absent.
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # `--component` takes one value; a bare second name is parsed as a toolchain.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags",
+ "crossterm_winapi",
  "document-features",
  "mio",
  "parking_lot",
  "rustix",
  "signal-hook",
  "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -193,6 +204,28 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,12 @@ path = "src/main.rs"
 # hand-drawing, ratatui layers on top rather than replacing anything.
 [dependencies]
 crossterm = { version = "0.29", default-features = false, features = ["events"] }
+
+# crossterm's `windows` feature is not optional on Windows — it gates the
+# winapi/crossterm_winapi backends, and the crate hard-fails the build with
+# `compile_error!` when it is absent. default-features = false drops it, so it
+# has to come back explicitly for the Windows target. The feature only pulls
+# dependencies that crossterm itself declares under cfg(windows), so scoping it
+# here keeps the Unix dependency graph exactly as it was.
+[target.'cfg(windows)'.dependencies]
+crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ with [Rust](https://rustup.rs) (≥ 1.78). No toolchain is needed on the fast pa
 
 **Platform status.** Developed and verified end-to-end on macOS (arm64). Linux binaries are
 built and the test suite runs on Linux in CI, but the install has not been exercised on a
-real Linux machine. Windows has no prebuilt binary and builds from source; nothing about it
-has been tested. If you run either, reports are very welcome — see the open issues.
+real Linux machine. Windows has no prebuilt binary and builds from source, and needs a Rust
+toolchain for that reason; the install, `probe`, and opening the manage pane have been
+verified on Windows 11 with herdr 0.7.5-preview in Windows Terminal (ConPTY), but the pane's
+keymap and a real `sync --prune` have not been exercised there. If you run Linux or Windows,
+reports are very welcome — see the open issues.
 
 Then open the manage pane from the command palette (**Lazy: open manage pane**), or
 bind it:
@@ -75,6 +78,12 @@ description = "manage plugins"
 
 Pick a key that is actually free — `prefix+l` is `focus_pane_right`, and `h`/`j`/`k`/`n`/`p`/
 `c`/`g` are taken too. `prefix+?` lists your active bindings.
+
+**On Windows** the config lives at `%APPDATA%\herdr\config.toml`, and the action to bind is
+`herdr-lazy.manage-windows`. herdr rejects duplicate action ids even when they are gated to
+platforms that cannot overlap, so the Windows entry needs its own id. Binding the plain
+`herdr-lazy.manage` there is accepted by the config parser and then does nothing, because
+that action is declared for macOS and Linux.
 
 ## Use
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -23,45 +23,106 @@ command = ["cargo", "build", "--release"]
 # list only when `auto-sync` is on — otherwise it exits immediately and silently. See
 # `cmd_startup` for why it installs missing plugins but never prunes or updates.
 [[startup]]
+platforms = ["linux", "macos"]
 command = ["./target/release/herdr-lazy", "startup"]
 
 # NOTE: the leading `./` is required. herdr resolves a pane's command through PATH, so a
 # bare `target/release/herdr-lazy` fails with "No viable candidates found in PATH" even
 # though the process runs with the plugin directory as its cwd. Actions happen to tolerate
 # the bare form, but every other plugin uses `./`, so keep both consistent.
+#
+# Windows needs a different shape again. herdr hands a relative program straight to
+# CreateProcessW, which neither appends `.exe` nor resolves it the way a shell would, so
+# `./target/release/herdr-lazy` simply never launches — the action fails with no exit code
+# and no stderr. Routing through `powershell -Command "& .\...exe"` gets the resolution
+# done by a shell that understands both the cwd and the extension. herdr also sets the
+# plugin cwd to a \\?\ verbatim path, which PowerShell handles but most things do not,
+# so the relative form is deliberate here rather than an absolute path built from
+# $env:HERDR_PLUGIN_ROOT.
+#
+# herdr rejects duplicate action and pane ids even when they are gated to disjoint
+# platforms, hence the `-windows` suffixes below.
+
+[[startup]]
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& .\\target\\release\\herdr-lazy.exe startup"]
 
 # Actions surface herdr-lazy inside herdr's command palette.
 [[actions]]
 id = "probe"
+platforms = ["linux", "macos"]
 title = "Lazy: probe CLI bridge"
 contexts = ["workspace"]
 command = ["./target/release/herdr-lazy", "probe"]
 
 [[actions]]
+id = "probe-windows"
+platforms = ["windows"]
+title = "Lazy: probe CLI bridge"
+contexts = ["workspace"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& .\\target\\release\\herdr-lazy.exe probe"]
+
+[[actions]]
 id = "init"
+platforms = ["linux", "macos"]
 title = "Lazy: install curated defaults"
 contexts = ["workspace"]
 command = ["./target/release/herdr-lazy", "init"]
 
 [[actions]]
+id = "init-windows"
+platforms = ["windows"]
+title = "Lazy: install curated defaults"
+contexts = ["workspace"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& .\\target\\release\\herdr-lazy.exe init"]
+
+[[actions]]
 id = "sync"
+platforms = ["linux", "macos"]
 title = "Lazy: sync plugins to bundle"
 contexts = ["workspace"]
 command = ["./target/release/herdr-lazy", "sync"]
+
+[[actions]]
+id = "sync-windows"
+platforms = ["windows"]
+title = "Lazy: sync plugins to bundle"
+contexts = ["workspace"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& .\\target\\release\\herdr-lazy.exe sync"]
 
 # Opens the pane rather than running the TUI directly: actions get no PTY, so `herdr-lazy ui`
 # invoked as an action fails with "Device not configured". See the script for the details.
 # This is also what a `type = "plugin_action"` keybinding ends up calling.
 [[actions]]
 id = "manage"
+platforms = ["linux", "macos"]
 title = "Lazy: open manage pane"
 contexts = ["workspace"]
 command = ["/bin/sh", "scripts/open-manage-pane.sh"]
+
+# Windows has no /bin/sh, so the same two-step — action asks herdr to open the pane —
+# is expressed inline. `& (…)` is not an option: PowerShell's call operator parses a
+# parenthesised expression as a command name, so the herdr binary has to land in a
+# variable first.
+[[actions]]
+id = "manage-windows"
+platforms = ["windows"]
+title = "Lazy: open manage pane"
+contexts = ["workspace"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "$b = $env:HERDR_BIN_PATH; if (-not $b) { $b = 'herdr' }; & $b plugin pane open --plugin herdr-lazy --entrypoint manage-windows --focus"]
 
 # The manage UI. `overlay` is the right placement for it: a temporary zoomed view that
 # hands focus back to whatever you were doing when it closes.
 [[panes]]
 id = "manage"
+platforms = ["linux", "macos"]
 title = "herdr-lazy"
 placement = "overlay"
 command = ["./target/release/herdr-lazy", "ui"]
+
+[[panes]]
+id = "manage-windows"
+platforms = ["windows"]
+title = "herdr-lazy"
+placement = "overlay"
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& .\\target\\release\\herdr-lazy.exe ui"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2272,4 +2272,85 @@ command = "something.else"
             "# extra: worktrunk — switch worktrees from a picker"
         );
     }
+
+    /// Returns `(table, platforms, program)` for every entry in the manifest, where
+    /// `program` is the first element of `command` and `platforms` is empty when the
+    /// entry declares none.
+    ///
+    /// Hand-rolled rather than pulling in a TOML parser: the shapes here are flat
+    /// single-line arrays, and the project keeps its dependency list at one.
+    fn manifest_entries(src: &str) -> Vec<(String, Vec<String>, String)> {
+        fn array_items(line: &str) -> Vec<String> {
+            let mut out = Vec::new();
+            let rest = match line.split_once('[') {
+                Some((_, r)) => r,
+                None => return out,
+            };
+            let mut chars = rest.chars();
+            let mut cur = String::new();
+            let mut inside = false;
+            for c in chars.by_ref() {
+                match c {
+                    '"' if inside => {
+                        out.push(std::mem::take(&mut cur));
+                        inside = false;
+                    }
+                    '"' => inside = true,
+                    ']' if !inside => break,
+                    _ if inside => cur.push(c),
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        let mut entries: Vec<(String, Vec<String>, String)> = Vec::new();
+        for raw in src.lines() {
+            let line = raw.trim();
+            if line.starts_with('#') {
+                continue;
+            }
+            if line.starts_with("[[") {
+                let table = line.trim_matches(|c| c == '[' || c == ']').to_string();
+                entries.push((table, Vec::new(), String::new()));
+                continue;
+            }
+            let Some(last) = entries.last_mut() else {
+                continue;
+            };
+            if line.starts_with("platforms") {
+                last.1 = array_items(line);
+            } else if line.starts_with("command") {
+                last.2 = array_items(line).first().cloned().unwrap_or_default();
+            }
+        }
+        entries
+    }
+
+    /// herdr hands a plugin's command to the platform's own process spawner. On Windows
+    /// that is CreateProcessW, which neither appends `.exe` nor resolves a relative
+    /// program the way a shell would, so `./target/release/herdr-lazy` never launches —
+    /// the action fails with no exit code and no stderr, which is a miserable thing to
+    /// debug. `/bin/sh` is not there to run either.
+    ///
+    /// An entry that declares no `platforms` applies to every platform, so it counts as
+    /// Windows-reachable. That is precisely how this was wrong: the actions, the startup
+    /// command and the pane were all unqualified, and all four were unspawnable.
+    #[test]
+    fn every_windows_reachable_command_names_a_program_windows_can_spawn() {
+        for (table, platforms, program) in manifest_entries(include_str!("../herdr-plugin.toml")) {
+            let reachable = platforms.is_empty() || platforms.iter().any(|p| p == "windows");
+            if !reachable || program.is_empty() {
+                continue;
+            }
+            assert!(
+                !program.starts_with("./"),
+                "[[{table}]] command `{program}` is relative; CreateProcessW will not resolve it"
+            );
+            assert!(
+                !program.starts_with('/'),
+                "[[{table}]] command `{program}` is a POSIX absolute path that Windows cannot run"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Makes the Windows install actually work. Refs #2.

Two independent blockers, neither of them the cargo-PATH problem you predicted — herdr found and ran `cargo` fine.

### 1. The build (`ae05961`)

`default-features = false` drops crossterm's `windows` feature, which isn't optional on that target: it gates the `winapi`/`crossterm_winapi` backends, and crossterm stops the build with `compile_error!` when it's missing. Installing died with 25 errors before any of your code compiled.

Restored for `cfg(windows)` only. It pulls just the dependencies crossterm itself declares under `cfg(windows)`, so the Unix graph is unchanged and there are no new direct dependencies — the count is still one.

The test that fails without it is a CI job. `platforms` claims windows, so the matrix now builds it rather than taking it on trust; that omission is also why this went unnoticed, since the matrix covered the two platforms that already worked.

### 2. The manifest (`a76c9a2`)

With the binary built, every action invoked through herdr still failed — status `failed`, no exit code, no stderr. The process never launched.

herdr hands the command to the platform's own spawner. On Windows that's `CreateProcessW`, which neither appends `.exe` nor resolves a relative program the way a shell does, so `./target/release/herdr-lazy` is never found. The comment above `[[startup]]` explains why the leading `./` is required — on Windows it's exactly what breaks. And `/bin/sh scripts/open-manage-pane.sh` has no interpreter there.

Existing entries are gated to linux/macos, with Windows twins going through `powershell -Command "& .\target\release\herdr-lazy.exe <sub>"`, which resolves both the extension and the `\\?\` verbatim path herdr sets as the plugin cwd. The manage action keeps your two-step — an action gets no PTY, so it asks herdr to open the pane — just expressed inline instead of in a shell script.

The test walks the manifest and asserts everything Windows can reach names a program Windows can start. An entry with no `platforms` counts as reachable, which is what makes it fail before the change: the startup command, all four actions and the pane were unqualified. It's hand-rolled rather than pulling in a TOML parser, to keep the dependency count where you have it.

### One decision that's yours

herdr rejects duplicate action and pane ids even when gated to platforms that can't overlap (`duplicate_plugin_action_id`), so the Windows entries carry a `-windows` suffix. That leaks to users: a `plugin_action` keybinding on Windows has to bind `herdr-lazy.manage-windows`, and binding the plain id there parses fine and then silently does nothing. I documented it in the README (`209f867`) because a silent no-op is a miserable way to meet this, but if you'd rather solve it differently — or raise it with herdr as a manifest limitation — this is the part to push back on.

### Verification

CI is green on all four jobs including the new Windows one: https://github.com/nonathaj/herdr-lazy/pull/1

Manually, on Windows 11 26200 / herdr 0.7.5-preview / Windows Terminal over ConPTY:

- `cargo fmt --check`, `cargo clippy --all-targets --target x86_64-pc-windows-msvc -- -D warnings`, `cargo test --locked --target x86_64-pc-windows-msvc` all pass — 111 tests
- `probe` invoked as a herdr action returns exit 0 with correct paths (`HERDR_PLUGIN_CONFIG_DIR` resolves; the `$HOME/.config` fallback is never reached)
- `manage` opens the overlay pane and the `ui` process stays alive

**Not verified**, and the README now says so rather than implying otherwise: the pane's keymap has not been driven, and no real `sync --prune` has been run on Windows. The pane itself was confirmed visually — it opens and renders correctly — but "installs, launches and draws" is the honest extent of it. Happy to go further if you want that before merging.

Your other two predictions came back clean — config resolution is fine via herdr, and raw mode plus the ANSI escapes appear to work under ConPTY.
