### PR TITLE
Filter the marketplace by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ because whether a plugin is still maintained matters more than how many stars it
 Search terms are ANDed and each may match the name, description or topics, so `worktree fzf`
 finds a worktree plugin whose description mentions fzf.
 
+`tab` narrows to a category — worktree, notifications, agents, and so on — for when you want
+to see what exists rather than search for something you can already name. It cycles back to
+`all`, and works alongside the query. Categories come from keywords matched against the name,
+description and topics, because GitHub topics alone miss more than half the plugins; anything
+that matches nothing lands in `other` rather than disappearing.
+
 Enter adds to your list rather than installing outright: one keystroke on a fuzzy match
 should not run a stranger's build script. The list is where intent is recorded.
 

--- a/src/browse.rs
+++ b/src/browse.rs
@@ -21,6 +21,9 @@ pub(crate) struct Browser {
     pub(crate) source_note: String,
     /// Names already in the user's list, so the browser can mark what is already handled.
     pub(crate) listed: Vec<String>,
+    /// The category filter, or `None` for everything. Cycled with tab; independent of the
+    /// query, so "worktree plugins mentioning fzf" is two narrowings rather than one guess.
+    pub(crate) category: Option<&'static str>,
 }
 
 impl Browser {
@@ -31,11 +34,54 @@ impl Browser {
             cursor: 0,
             source_note,
             listed,
+            category: None,
         }
     }
 
     pub(crate) fn results(&self) -> Vec<&Entry> {
-        self.all.iter().filter(|e| e.matches(&self.query)).collect()
+        self.all
+            .iter()
+            .filter(|e| e.matches(&self.query))
+            .filter(|e| match self.category {
+                Some(c) => crate::category::classify(e) == c,
+                None => true,
+            })
+            .collect()
+    }
+
+    /// Tab — step through the categories, ending back at "everything".
+    ///
+    /// A cycle rather than a menu: there are ten of them, the list is short enough to walk, and
+    /// a second overlay on top of the search overlay is a worse way to narrow a list than one
+    /// key you can hold.
+    pub(crate) fn cycle_category(&mut self, forward: bool) {
+        let names = crate::category::names();
+        // `None` is position 0, so the ring is "everything" followed by each category.
+        let at = match self.category {
+            None => 0,
+            Some(c) => names
+                .iter()
+                .position(|n| *n == c)
+                .map(|i| i + 1)
+                .unwrap_or(0),
+        };
+        let len = names.len() + 1;
+        let next = if forward {
+            (at + 1) % len
+        } else {
+            (at + len - 1) % len
+        };
+        self.category = if next == 0 {
+            None
+        } else {
+            names.get(next - 1).copied()
+        };
+        self.cursor = 0;
+    }
+
+    /// What the header says is being shown.
+    pub(crate) fn category_label(&self) -> &'static str {
+        self.category.unwrap_or("all")
     }
 
     pub(crate) fn selected(&self) -> Option<&Entry> {
@@ -209,6 +255,50 @@ mod tests {
             }
             assert_eq!(b.query, q, "{} was mangled", q);
         }
+    }
+
+    #[test]
+    fn a_category_narrows_the_list_and_tab_gets_back_to_everything() {
+        let mut b = browser();
+        assert_eq!(b.category_label(), "all");
+
+        b.category = Some("worktree");
+        let r = b.results();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].full_name, "b/herdr-worktrunk");
+
+        // The ring starts at "everything" and returns to it, so tab is never a trap.
+        b.category = None;
+        let steps = crate::category::names().len() + 1;
+        for _ in 0..steps {
+            b.cycle_category(true);
+        }
+        assert_eq!(b.category, None);
+    }
+
+    /// Filtering by category and typing a query are independent narrowings.
+    #[test]
+    fn a_category_and_a_query_both_apply() {
+        let mut b = browser();
+        b.category = Some("worktree");
+        for c in "phone".chars() {
+            b.push(c);
+        }
+        assert!(
+            b.results().is_empty(),
+            "the phone plugin is not a worktree one"
+        );
+        assert!(b.selected().is_none());
+    }
+
+    /// Changing the filter must not leave the cursor pointing into the old result set.
+    #[test]
+    fn changing_category_returns_to_the_top() {
+        let mut b = browser();
+        b.move_down();
+        b.move_down();
+        b.cycle_category(true);
+        assert_eq!(b.cursor, 0);
     }
 
     #[test]

--- a/src/category.rs
+++ b/src/category.rs
@@ -1,0 +1,163 @@
+//! Sorting the marketplace into categories, so it can be browsed and not only searched.
+//!
+//! GitHub topics cannot do this job. Half the published plugins carry no usable topic at all
+//! (only `herdr` / `herdr-plugin`), and the ones that exist mix purpose with technology —
+//! `worktree` next to `rust` and `ratatui`. Measured against the index, worktree plugins are
+//! 13 by topic and 31 by what their name and description actually say.
+//!
+//! So a category is a set of keywords matched against name, description and topics. That is
+//! the opposite choice from `extras`, deliberately: an extra is hand-picked because install
+//! quality has to be certain, while browsing wants coverage of the long tail. A plugin landing
+//! in a slightly odd category costs a moment; a plugin nobody can find costs everything.
+//!
+//! Categories share their names with the extras vocabulary so the two views agree, even though
+//! membership is decided differently.
+
+use crate::registry::Entry;
+
+/// `(category, keywords)`, in priority order — the first category with a hit wins.
+///
+/// Order is the whole design. Specific purposes come before broad ones: nearly every plugin
+/// mentions a pane or a workspace somewhere, so those keywords would swallow the list if they
+/// were consulted first.
+pub(crate) const CATEGORIES: &[(&str, &[&str])] = &[
+    ("worktree", &["worktree", "worktrunk"]),
+    (
+        "notifications",
+        &["notification", "notify", "ntfy", "alert", "blocked", "idle"],
+    ),
+    (
+        "keybindings",
+        &[
+            "keymap",
+            "keybinding",
+            "which-key",
+            "whichkey",
+            "which key",
+            "hotkey",
+            "shortcut",
+            "palette",
+        ],
+    ),
+    (
+        "navigation",
+        &[
+            "picker", "pick", "fuzzy", "fzf", "jump", "switch", "pluck", "grep", "search",
+            "navigat",
+        ],
+    ),
+    (
+        "review",
+        &["review", "diff", "pull request", "commit", "github"],
+    ),
+    ("files", &["file", "viewer", "tree", "directory", "sidebar"]),
+    (
+        "status",
+        &["status", "monitor", "dashboard", "live", "progress"],
+    ),
+    (
+        "session",
+        &["session", "tmux", "resurrect", "persist", "restore"],
+    ),
+    (
+        "workspace",
+        &["workspace", "project", "layout", "template", "tab", "pane"],
+    ),
+    (
+        "agents",
+        &["agent", "claude", "codex", "coding", "llm", "prompt"],
+    ),
+];
+
+/// Where a plugin that matches nothing goes. Named, not dropped: a bucket you can open is the
+/// difference between "this filter is incomplete" and "my plugin has vanished".
+pub(crate) const OTHER: &str = "other";
+
+/// Every category name, in display order, with `other` last.
+pub(crate) fn names() -> Vec<&'static str> {
+    let mut v: Vec<&'static str> = CATEGORIES.iter().map(|(c, _)| *c).collect();
+    v.push(OTHER);
+    v
+}
+
+pub(crate) fn classify(e: &Entry) -> &'static str {
+    let haystack = format!(
+        "{} {} {}",
+        e.full_name.to_lowercase(),
+        e.description.to_lowercase(),
+        e.topics.join(" ").to_lowercase()
+    );
+    CATEGORIES
+        .iter()
+        .find(|(_, keywords)| keywords.iter().any(|k| haystack.contains(k)))
+        .map(|(c, _)| *c)
+        .unwrap_or(OTHER)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, desc: &str, topics: &[&str]) -> Entry {
+        Entry {
+            full_name: name.to_string(),
+            description: desc.to_string(),
+            stars: 0,
+            language: "Rust".to_string(),
+            topics: topics.iter().map(|t| t.to_string()).collect(),
+            url: String::new(),
+            pushed_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn a_plugin_is_placed_by_what_it_says_it_does() {
+        assert_eq!(
+            classify(&entry("b/herdr-worktrunk", "switch git worktrees", &[])),
+            "worktree"
+        );
+        assert_eq!(
+            classify(&entry("a/herdr-ntfy", "push to your phone", &[])),
+            "notifications"
+        );
+    }
+
+    /// The measured failure of topic-only classification: the topic says nothing useful, and
+    /// the description says everything.
+    #[test]
+    fn the_description_counts_even_when_the_topics_do_not() {
+        let e = entry(
+            "someone/herdr-thing",
+            "Switch between worktrees from a picker",
+            &["herdr", "rust"],
+        );
+        assert_eq!(classify(&e), "worktree");
+    }
+
+    /// Order is the design: almost every plugin mentions a pane, so a broad category must not
+    /// be consulted before a specific one.
+    #[test]
+    fn a_specific_purpose_beats_a_broad_one() {
+        let e = entry(
+            "x/herdr-worktree-pane",
+            "opens a workspace pane for each worktree",
+            &[],
+        );
+        assert_eq!(classify(&e), "worktree", "not workspace");
+    }
+
+    /// Matching nothing is a category, not a disappearance.
+    #[test]
+    fn an_unclassifiable_plugin_lands_in_other() {
+        assert_eq!(classify(&entry("x/herdr-thing", "", &[])), OTHER);
+        assert_eq!(*names().last().unwrap(), OTHER);
+    }
+
+    #[test]
+    fn matching_ignores_case() {
+        assert_eq!(
+            classify(&entry("X/Herdr-Worktree", "WORKTREE tooling", &[])),
+            "worktree"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@
 //! only its name can be compared), and `--prune` acts on Strong only.
 
 mod browse;
+mod category;
 mod extras;
 mod github;
 mod json;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1435,7 +1435,12 @@ impl App {
             b.all.len(),
             b.source_note
         )?;
-        writeln!(out, " search: \x1b[1m{}\x1b[0m\x1b[7m \x1b[0m\r", b.query)?;
+        writeln!(
+            out,
+            " search: \x1b[1m{}\x1b[0m\x1b[7m \x1b[0m  \x1b[2m[tab]\x1b[0m \x1b[1m{}\x1b[0m\r",
+            b.query,
+            b.category_label()
+        )?;
         writeln!(out, "\x1b[2m{}\x1b[0m\r", rule)?;
 
         let visible = (height as usize).saturating_sub(6).max(1);
@@ -1473,9 +1478,9 @@ impl App {
 
         let footer = match &self.flash {
             Some(msg) => format!("\x1b[36m{}\x1b[0m", msg),
-            None => "\x1b[1m[enter]\x1b[0m add to your list  \x1b[1m[ctrl+o]\x1b[0m open repo  \
-                     \x1b[1m[↑↓]\x1b[0m move  \x1b[1m[ctrl+r]\x1b[0m refresh  \
-                     \x1b[1m[esc]\x1b[0m back"
+            None => "\x1b[1m[enter]\x1b[0m add to your list  \x1b[1m[tab]\x1b[0m category  \
+                     \x1b[1m[ctrl+o]\x1b[0m open repo  \x1b[1m[↑↓]\x1b[0m move  \
+                     \x1b[1m[ctrl+r]\x1b[0m refresh  \x1b[1m[esc]\x1b[0m back"
                 .to_string(),
         };
         write!(
@@ -1984,6 +1989,9 @@ fn event_loop(out: &mut impl Write) -> io::Result<()> {
                 }
                 KeyCode::Down => app.browser.as_mut().unwrap().move_down(),
                 KeyCode::Up => app.browser.as_mut().unwrap().move_up(),
+                // Tab, because every printable key belongs to the query here.
+                KeyCode::Tab => app.browser.as_mut().unwrap().cycle_category(true),
+                KeyCode::BackTab => app.browser.as_mut().unwrap().cycle_category(false),
                 KeyCode::Backspace => {
                     app.flash = None;
                     app.browser.as_mut().unwrap().backspace();


### PR DESCRIPTION
Closes #19.

`/` searches the marketplace by free text, which only helps when you can already name the
thing. `tab` now narrows to a category — worktree, notifications, agents — for when you want to
see what exists. It cycles back to `all`, and applies alongside the query.

## Why keywords and not topics

GitHub topics cannot do this job, measured against the index (#13): half the published plugins
carry no usable topic at all, and the ones that exist mix purpose with technology — `worktree`
next to `rust` and `ratatui`. Worktree plugins are 13 by topic and 31 by what their name and
description say.

So a category is a keyword set matched against name, description and topics. That is the
opposite of how `extras` decides membership, deliberately: an extra is hand-picked because
install quality has to be certain, while browsing wants coverage of the long tail. A plugin in
a slightly odd category costs a moment; a plugin nobody can find costs everything.

Category names are shared with the extras vocabulary so the two views agree.

## Order is the design

Almost every plugin mentions a pane or a workspace somewhere, so the broad categories are
consulted last — otherwise they swallow the list. First match wins, specific before broad.

Run against the 345 cached entries: 30 fall through to `other` (~9%), and reading them, they
are genuinely uncategorisable — empty descriptions, plugin collections, one-off integrations.
`other` is a bucket you can open, not a silent drop: "this filter is incomplete" and "my plugin
has vanished" are different messages.

## Notes

- `tab`, because every printable key belongs to the query in this view — the same constraint
  that already keeps `a` and `o` out of the browser's keymap.
- Changing the filter returns the cursor to the top, like typing does.

## Tests

124 total, 9 new: classification by description when topics are useless, specific-beats-broad
ordering, `other` as a real category, case-insensitivity, the cycle returning to `all`, query
and category applying together, and the cursor reset.

`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.

Not verified: the pane was not opened on a real terminal for this change.
