### PR TITLE
Declare the herdr version the first run actually needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ manage the *other* plugins.
 
 ## Install
 
-Requires herdr ≥ 0.7.0.
+Requires herdr ≥ 0.7.5, which is where the `[[startup]]` hook the first run depends on
+arrives. Earlier versions used to install this and then quietly do nothing.
 
 ```sh
 herdr plugin install natori-hrj/herdr-lazy
@@ -67,9 +68,9 @@ verified on Windows 11 with herdr 0.7.5-preview in Windows Terminal (ConPTY), bu
 keymap and a real `sync --prune` have not been exercised there. If you run Linux or Windows,
 reports are very welcome — see the open issues.
 
-**The first herdr start after installing sets the machine up** (a `[[startup]]` hook, herdr
-0.7.5+): it writes the curated list, installs what the list names, and binds `prefix+shift+l`
-to the manage pane. It prints everything it did. Press the key and you are in.
+**The first herdr start after installing sets the machine up** (a `[[startup]]` hook): it
+writes the curated list, installs what the list names, and binds `prefix+shift+l` to the
+manage pane. It prints everything it did. Press the key and you are in.
 
 That happens only on a machine that has plainly never been set up — no plugin list, and
 nothing installed but herdr-lazy itself. If you already have plugins, or already have a list,
@@ -327,7 +328,7 @@ herdr-lazy restore
 ## Keeping in sync automatically
 
 Press `A` in the manage pane. herdr-lazy then installs anything on your list that is missing
-whenever herdr starts (a `[[startup]]` hook, herdr 0.7.5+) — open herdr on a new machine with
+whenever herdr starts (the same `[[startup]]` hook the first run uses) — open herdr on a new machine with
 a list already in place and your plugins appear on their own. The header shows `auto-sync on`
 while it is active.
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,11 @@
 id = "herdr-lazy"
 name = "herdr-lazy"
 version = "0.21.0"
-min_herdr_version = "0.7.0"
+# 0.7.5, not 0.7.0, because of the `[[startup]]` hook below: it does not exist before 0.7.5,
+# and the first-run setup depends on it entirely. Claiming 0.7.0 meant herdr-lazy installed
+# happily on an older herdr and then quietly never set the machine up — and it could not even
+# say so, since the hook that would have printed the message is the missing one.
+min_herdr_version = "0.7.5"
 description = "Be lazy: a curated, batteries-included plugin distro & manager for herdr"
 platforms = ["linux", "macos", "windows"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2660,6 +2660,27 @@ command = "something.else"
         }
     }
 
+    /// The floor herdr enforces and the floor the README promises have to be the same number.
+    ///
+    /// They disagreed once already — the manifest said 0.7.0 while the first-run setup needed
+    /// the 0.7.5 startup hook — and the failure mode was silent: herdr-lazy installed on an
+    /// older herdr and then did nothing, with no way to say why, because the missing hook is
+    /// the thing that would have printed the message.
+    #[test]
+    fn the_readme_and_the_manifest_agree_on_the_herdr_floor() {
+        let floor = include_str!("../herdr-plugin.toml")
+            .lines()
+            .find(|l| l.trim_start().starts_with("min_herdr_version"))
+            .and_then(|l| l.split('"').nth(1))
+            .expect("the manifest declares a floor");
+        let promised = format!("Requires herdr ≥ {}", floor);
+        assert!(
+            include_str!("../README.md").contains(&promised),
+            "README does not say `{}`",
+            promised
+        );
+    }
+
     /// Until herdr resolves relative commands on Windows (#28), every action and pane is
     /// declared twice — once for Unix, once for Windows under a `-windows` id. Nothing stops
     /// someone adding only one half, and nothing would fail: the test above only checks that


### PR DESCRIPTION
The manifest claimed `min_herdr_version = "0.7.0"` while the first-run setup depends entirely
on the `[[startup]]` hook, which does not exist before 0.7.5. Both the manifest's own comment
and the README said 0.7.5 next to the feature; only the number herdr enforces was wrong.

The failure that produced was silent, and could not have been anything else: herdr-lazy
installed happily on an older herdr and then never set the machine up — and it could not say
why, because the hook that would have printed the message is the one that is missing. Nothing
logs, nothing warns, the key is never bound and the list is never written.

## Changes

- `min_herdr_version = "0.7.5"`, with the reason recorded next to it
- README says `Requires herdr ≥ 0.7.5` and explains which feature sets the floor
- dropped the now-redundant "herdr 0.7.5+" notes beside the startup hook — the floor covers them
- a test that the manifest and the README quote the same number

## Why the test

This project keeps meeting the same shape of bug: two files that must agree, with a silent
failure when they do not — release asset names against `fetch-or-build.sh`, the Windows
manifest twins (#29), and now this. Cheap to guard, so guarded. Verified by moving the manifest
to 0.8.0 and watching it fail with `README does not say 'Requires herdr ≥ 0.8.0'`.

## User-visible

Anyone on herdr 0.7.0–0.7.4 can no longer install herdr-lazy. That is the point: they were
installing something that did not work for them and had no way to find out. Worth a line in the
release notes.

Refs #28 — raising this floor is also the precondition for collapsing the Windows manifest
twins, though that waits for a herdr release carrying `b499e611b6`.
