### PR TITLE
Start from someone else's list with init --from

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ herdr-lazy sync --prune  # also uninstall anything not in the list
 
 herdr-lazy extras                    # list the opt-in extras
 herdr-lazy init --extras worktrunk   # defaults plus a chosen extra
+herdr-lazy init --from owner/repo    # start from someone else's list instead
 ```
 
 `sync` and `update` take plugin names to work on just those:
@@ -147,7 +148,7 @@ herdr-lazy update smarzban/herdr-file-viewer
 
 | command | what it does |
 |---|---|
-| `init [--force] [--extras <id,…>]` | write the curated default bundle, plus any opt-in extras |
+| `init [--force] [--extras <id,…>] [--from <owner/repo[@ref]>]` | write the curated default bundle, or adopt someone else's list |
 | `extras` | list the opt-in extras (`e` in the pane picks them interactively) |
 | `list` | show the desired plugin set |
 | `install [<repo>…]` | install what is missing, restore drifted pins |
@@ -426,6 +427,24 @@ depends on where you want to be pinged — not a decision a default set should m
 None of this is load-bearing: `init` just writes these lines into `plugins.list`. Edit it,
 or skip `init` and build your own with `add`.
 
+## Starting from someone else's list
+
+```sh
+herdr-lazy init --from owner/repo        # their plugins.list becomes yours
+herdr-lazy init --from owner/repo@v1     # at a ref, if you would rather it not move
+```
+
+It reads `plugins.list` from the root of that repository and writes it as your list, comments
+and all. After that it is your file: there is no upstream, no link back, and nothing to update
+from. A fork, not a subscription — the whole point is that you can now disagree with it.
+
+The lockfile does not come with it. Their list means the same plugins; their lock would mean
+the same commits, which is a much stronger thing to accept from a stranger.
+
+Nothing is installed by this, as with any `init` — you get a list to read first, and `sync`
+when you agree with it. It refuses to overwrite an existing list without `--force`, and it
+refuses anything that does not look like a plugin list rather than writing it over yours.
+
 ## Extras
 
 The default bundle stays out of choices that depend on you — which worktree tool, which
@@ -464,8 +483,6 @@ the rest still needs design.
   fine everywhere else. The manifest is readable before install, so the browser could say so.
 - **`check`** — show what has updates without applying any, the way `update` does but
   read-only. Needs a plan for GitHub API rate limits.
-- **Starter lists** — `init --from owner/repo`, so a curated list can be shared and adopted
-  the way people fork a LazyVim starter.
 - **enable / disable from the pane** — herdr supports both; herdr-lazy only reports the state.
 
 ## Design notes

--- a/src/github.rs
+++ b/src/github.rs
@@ -41,6 +41,26 @@ pub(crate) fn changes_since(owner_repo: &str, installed_commit: &str) -> Changes
     parse_commits(&body, installed_commit)
 }
 
+/// Fetch a file from a repository at a ref, as raw text.
+///
+/// `HEAD` is the default rather than `main`: raw.githubusercontent resolves it to whatever the
+/// repository calls its default branch, so nothing here has to guess a branch name.
+/// Overridable so the fetch itself can be exercised, rather than only ever being proven by its
+/// failure path — the same reason `scripts/fetch-or-build.sh` takes a base URL.
+pub(crate) fn raw_file(owner_repo: &str, reference: Option<&str>, path: &str) -> Option<String> {
+    let base = std::env::var("HERDR_LAZY_RAW_BASE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "https://raw.githubusercontent.com".to_string());
+    fetch(&format!(
+        "{}/{}/{}/{}",
+        base,
+        owner_repo,
+        reference.unwrap_or("HEAD"),
+        path
+    ))
+}
+
 /// Shell out to curl/wget — std has no TLS, the same reason the install script and the
 /// marketplace fetch do.
 fn fetch(url: &str) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,7 +600,19 @@ fn extras_arg(rest: &[&str]) -> Vec<String> {
     out
 }
 
-/// Write the curated default bundle (the distro layer), plus any opt-in extras.
+/// Parse `--from owner/repo` or `--from=owner/repo`.
+fn from_arg<'a>(rest: &[&'a str]) -> Option<&'a str> {
+    for (i, a) in rest.iter().enumerate() {
+        if let Some(v) = a.strip_prefix("--from=") {
+            return (!v.is_empty()).then_some(v);
+        }
+        if *a == "--from" {
+            return rest.get(i + 1).copied().filter(|v| !v.starts_with("--"));
+        }
+    }
+    None
+}
+
 /// The list `init` writes: the curated defaults, then any chosen extras under their comments.
 ///
 /// A function rather than inline, because the first-run bootstrap writes the same file. A new
@@ -636,7 +648,79 @@ fn default_bundle_body(chosen: &[extras::Extra]) -> String {
     body
 }
 
-fn cmd_init(force: bool, extra_ids: &[String]) -> io::Result<()> {
+/// A line that declares a plugin, as opposed to a comment or a blank.
+fn is_entry_line(l: &str) -> bool {
+    let l = l.trim();
+    !l.is_empty() && !l.starts_with('#')
+}
+
+/// `owner/repo`, optionally with a subdirectory — and nothing that looks like prose or markup.
+///
+/// This is the check that stops a fetched HTML error page, or a file that happens to live at
+/// that path and is not a plugin list, from being written over someone's list.
+fn looks_like_entry(l: &str) -> bool {
+    let repo = Spec::parse(l).repo;
+    !repo.is_empty()
+        && repo.contains('/')
+        && !repo.starts_with('/')
+        && !repo.ends_with('/')
+        && repo
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "._-/".contains(c))
+}
+
+/// Fetch someone else's `plugins.list` and return what to write.
+///
+/// A copy, deliberately: nothing records where it came from except a comment, there is no
+/// upstream to track and no update channel. Adopting a list must not make the manager depend
+/// on someone else's opinion — that is the whole difference between a starter and a
+/// subscription.
+///
+/// The lockfile is not adopted with it. Taking someone's list means the same plugins; taking
+/// their lock would mean the same commits, which is a far stronger claim to place in a
+/// stranger's hands. If that is ever wanted it should be asked for separately.
+fn adopt_body(spec: &str) -> Result<String, String> {
+    let s = Spec::parse(spec);
+    if !looks_like_entry(&s.repo) || s.repo.matches('/').count() != 1 {
+        return Err(format!(
+            "`{}` is not an owner/repo (optionally owner/repo@ref)",
+            spec
+        ));
+    }
+    let body =
+        github::raw_file(&s.repo, s.reference.as_deref(), "plugins.list").ok_or_else(|| {
+            format!(
+                "could not read plugins.list from {} — is there one at the repository root?",
+                spec
+            )
+        })?;
+
+    let entries: Vec<&str> = body.lines().filter(|l| is_entry_line(l)).collect();
+    if entries.is_empty() {
+        return Err(format!("{} has a plugins.list, but it lists nothing", spec));
+    }
+    if let Some(bad) = entries.iter().find(|l| !looks_like_entry(l)) {
+        return Err(format!(
+            "{} does not look like a plugin list — found `{}`",
+            spec,
+            bad.trim()
+        ));
+    }
+
+    // Provenance as a comment, not as state: it tells a reader where this came from without
+    // creating anything the tool has to keep in step.
+    let mut out = format!(
+        "# adopted from {} — a copy, not a subscription. Edit it freely.\n\n",
+        spec
+    );
+    out.push_str(&body);
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+fn cmd_init(force: bool, extra_ids: &[String], from: Option<&str>) -> io::Result<()> {
     let p = bundle_path();
     if p.exists() && !force {
         println!(
@@ -663,9 +747,40 @@ fn cmd_init(force: bool, extra_ids: &[String]) -> io::Result<()> {
         return Ok(());
     }
 
+    // Someone else's list, if asked for — resolved before writing, so a repo that has no list
+    // leaves the existing one alone rather than replacing it with the defaults.
+    let adopted = match from {
+        Some(spec) => match adopt_body(spec) {
+            Ok(body) => Some((spec.to_string(), body)),
+            Err(msg) => {
+                eprintln!("{}", msg);
+                return Ok(());
+            }
+        },
+        None => None,
+    };
+
     ensure_parent(&p)?;
-    fs::write(&p, default_bundle_body(&chosen))?;
-    println!("wrote curated default bundle -> {}", p.display());
+    let base = match &adopted {
+        Some((_, body)) => body.clone(),
+        None => default_bundle_body(&chosen),
+    };
+    fs::write(&p, base)?;
+    // An adopted list is written verbatim, so any extras asked for still have to be appended —
+    // the same append the pane uses, so the two cannot produce different files.
+    if adopted.is_some() {
+        for e in &chosen {
+            let _ = add_extra_to_list(e);
+        }
+    }
+    match &adopted {
+        Some((spec, body)) => {
+            let n = body.lines().filter(|l| is_entry_line(l)).count();
+            println!("adopted {} plugin(s) from {} -> {}", n, spec, p.display());
+            println!("it is your list now — no link back to {}.", spec);
+        }
+        None => println!("wrote curated default bundle -> {}", p.display()),
+    }
     if !chosen.is_empty() {
         println!("with extras:");
         for e in &chosen {
@@ -1846,7 +1961,8 @@ fn print_help() {
     println!("herdr-lazy — be lazy: a curated plugin distro & manager for herdr\n");
     println!("USAGE: herdr-lazy <command>\n");
     println!("  probe             verify the plugin <-> herdr CLI bridge (run this first)");
-    println!("  init [--force] [--extras <id,…>]  write the default bundle (the distro layer)");
+    println!("  init [--force] [--extras <id,…>] [--from <owner/repo[@ref]>]");
+    println!("                    write the default bundle, or adopt someone else's list");
     println!("  extras            list the opt-in extras you can pass to `init --extras`");
     println!("  list              show desired plugins");
     println!("  install [<repo>…] install what is missing, restore drifted pins");
@@ -1869,7 +1985,11 @@ fn main() {
         "probe" => cmd_probe(),
         "startup" => cmd_startup(),
         "auto-sync" => cmd_auto_sync(rest.first().copied()),
-        "init" => cmd_init(rest.contains(&"--force"), &extras_arg(&rest)),
+        "init" => cmd_init(
+            rest.contains(&"--force"),
+            &extras_arg(&rest),
+            from_arg(&rest),
+        ),
         "extras" => cmd_extras(),
         "list" => cmd_list(),
         // `install` is what people look for; `sync` is what the operation is. Both, rather
@@ -2658,6 +2778,38 @@ command = "something.else"
                 "[[{table}]] command `{program}` is a POSIX absolute path that Windows cannot run"
             );
         }
+    }
+
+    #[test]
+    fn from_takes_a_repo_in_either_form() {
+        assert_eq!(from_arg(&["--from", "owner/repo"]), Some("owner/repo"));
+        assert_eq!(from_arg(&["--from=owner/repo@v1"]), Some("owner/repo@v1"));
+        assert_eq!(from_arg(&["init", "--force"]), None);
+        // A flag is not a value: `--from --force` must not adopt a repo called "--force".
+        assert_eq!(from_arg(&["--from", "--force"]), None);
+        assert_eq!(from_arg(&["--from"]), None);
+    }
+
+    /// The guard that stops a fetched HTML error page — or any file that is not a plugin list —
+    /// being written over someone's list.
+    #[test]
+    fn only_owner_repo_lines_count_as_entries() {
+        assert!(looks_like_entry("owner/repo"));
+        assert!(looks_like_entry("owner/repo@v1.2.0"));
+        assert!(looks_like_entry("owner/repo/plugins/sub"));
+        assert!(!looks_like_entry("<!DOCTYPE html>"));
+        assert!(!looks_like_entry("404: Not Found"));
+        assert!(!looks_like_entry("just-a-name"));
+        assert!(!looks_like_entry("/leading"));
+        assert!(!looks_like_entry("trailing/"));
+        assert!(!looks_like_entry(""));
+    }
+
+    #[test]
+    fn comments_and_blanks_are_not_entries() {
+        assert!(is_entry_line("owner/repo"));
+        assert!(!is_entry_line("# a comment"));
+        assert!(!is_entry_line("   "));
     }
 
     /// The floor herdr enforces and the floor the README promises have to be the same number.


### PR DESCRIPTION
Closes #20.

```sh
herdr-lazy init --from owner/repo        # their plugins.list becomes yours
herdr-lazy init --from owner/repo@v1     # at a ref, if you would rather it not move
```

Of the three things the list should be — ownable, shareable, reproducible — sharing was the
untouched one. This is the smallest thing that makes a list shareable at all: read
`plugins.list` from the root of a repository, write it as yours, comments and all.

## The decisions #20 left open

- **Fixed path**, `plugins.list` at the root. `owner/repo` stays a handle you can say out loud
  instead of a URL that has to be copied exactly.
- **Default ref is `HEAD`**, which raw.githubusercontent resolves to whatever the repository
  calls its default branch — so nothing here guesses a branch name. `@ref` pins it.
- **The lockfile does not come with it.** Their list means the same plugins; their lock would
  mean the same commits, which is a far stronger thing to accept from a stranger. If that is
  ever wanted, it should be asked for separately.
- **Written verbatim.** A list's comments carry meaning — `# extra:` headers most obviously —
  so reformatting someone's file on the way in would lose information.
- **Provenance is a comment, not state.** One line saying where it came from. Nothing to track,
  nothing to keep in step, no upstream. A fork, not a subscription: the point is that you can
  now disagree with it.

## Failure is where this had to be right

The failure mode of this command is destroying a list someone spent months on. All four paths
were exercised against a real fetch, and none of them writes:

| | |
|---|---|
| repository has no `plugins.list` | error, nothing written |
| `--from not-a-repo` | error before fetching |
| fetch returns an HTML 404 page | rejected as "does not look like a plugin list" |
| a list already exists | refuses, prints the `--force` hint |

`looks_like_entry` is what rejects the third: an entry has to parse as `owner/repo` with no
prose or markup in it. Without that, a stray file at that path is written over yours.

Nothing is installed, as with any `init` — you get a list to read, and `sync` when you agree
with it.

## Notes

- `github::raw_file` takes an overridable base URL, so the success path could be exercised
  rather than only ever proven by its failures — the same reasoning as `fetch-or-build.sh`.
- `--from` composes with `--extras`: the adopted list is written, then extras append through
  the same path the pane uses.
- The roadmap's "Starter lists" entry is removed, being this.

## Tests

129 total, 3 new: `--from` argument forms including `--from --force` not adopting a repo called
`--force`, what counts as an entry line, and what `looks_like_entry` rejects.

`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.

Not verified: no real repository publishes a `plugins.list` yet, so the live success path was
exercised through the base-URL override rather than against GitHub.
