### PR TITLE
Extras you write yourself, beside your list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,11 @@ Self-submissions are welcome and held to exactly this list, and so are the maint
 plugins: being written by the author is not a reason to include something here, the same way
 it is not for the default set.
 
+If the grouping you want is a personal one — "the three things I install on every machine" —
+you do not need this repository at all. A `.list` file in `extras/` beside your own plugin list
+joins your menu directly; see the README. The bar above is for what ships to everyone, and it
+would be the wrong thing to lower for a bundle only you use.
+
 ## Reporting a bug
 
 The useful ones tend to include:

--- a/README.md
+++ b/README.md
@@ -467,6 +467,25 @@ they are two extras you choose between — `--extras` never stacks them, the sam
 default set swaps rather than adds. Each extra's description names any external setup it needs
 (a CLI to install, a service to configure) so opting in is an informed choice.
 
+### Extras of your own
+
+An extra is a `.list` file with two comment lines, which is a format you can write by hand.
+Drop one in `extras/` beside your plugin list and it joins the menu — no pull request, nothing
+to convince anyone of:
+
+```
+# category: mine
+# the three things I install on every machine
+cloudmanic/herdr-plus
+smarzban/herdr-file-viewer
+```
+
+Saved as `extras/mine.list`, that is `herdr-lazy init --extras mine`, and a row marked `*` in
+the pane. It sits beside the list rather than in a config directory for the reason the lockfile
+does: if you keep your list in a dotfiles repo, the things you wrote belong there too. Giving
+one the same name as a bundled extra replaces it, and the listing says so. A file that lists no
+plugins is reported and skipped, never a crash and never a silent disappearance.
+
 Extras are plain `owner/repo` lists under [`extras/`](extras/), embedded at build time, so
 listing one never touches the network. Adding an extra is a small, reviewed pull request —
 drop a file in `extras/` and add a line to the registry. The bar it clears is in

--- a/src/extras.rs
+++ b/src/extras.rs
@@ -12,10 +12,21 @@
 
 /// A named, opt-in capability: one entry in the extras menu.
 pub(crate) struct Extra {
-    pub id: &'static str,
+    pub id: String,
     pub category: String,
     pub description: String,
     pub plugins: Vec<String>,
+    /// Where it came from. Shown in the listing, because "reviewed and shipped with the tool"
+    /// and "a file I wrote last Tuesday" are different claims about the same menu entry.
+    pub source: Source,
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub(crate) enum Source {
+    /// Embedded at build time from `extras/`, having cleared the bar in CONTRIBUTING.
+    Bundled,
+    /// A `.list` file the user wrote, beside their plugin list. Answerable to nobody.
+    Local,
 }
 
 impl Extra {
@@ -35,24 +46,83 @@ const REGISTRY: &[(&str, &str)] = &[
     ("worktrunk", include_str!("../extras/worktrunk.list")),
 ];
 
-/// All extras, in registry order, parsed from their embedded definitions.
-pub(crate) fn all() -> Vec<Extra> {
-    REGISTRY.iter().map(|(id, body)| parse(id, body)).collect()
+/// Where a user's own extras live: `extras/` beside their plugin list.
+///
+/// Beside the list rather than in the config directory, for the reason the lockfile is: someone
+/// who moved their list into a dotfiles repo means to keep the things they wrote there too. A
+/// hand-written extra is content, not state.
+pub(crate) fn local_dir() -> std::path::PathBuf {
+    crate::bundle_path().with_file_name("extras")
 }
 
-/// Look up one extra by id.
-pub(crate) fn find(id: &str) -> Option<Extra> {
-    REGISTRY
+/// Every extra on offer: the bundled ones, plus whatever the user has written.
+///
+/// A local extra with the same id as a bundled one replaces it. That is the least surprising
+/// outcome for the person who wrote the file — but the listing says so rather than letting it
+/// happen quietly.
+pub(crate) fn all() -> Vec<Extra> {
+    let (local, _) = local();
+    let mut out: Vec<Extra> = REGISTRY
         .iter()
-        .find(|(eid, _)| *eid == id)
-        .map(|(eid, body)| parse(eid, body))
+        .filter(|(id, _)| !local.iter().any(|l| l.id == *id))
+        .map(|(id, body)| parse(id, body, Source::Bundled))
+        .collect();
+    out.extend(local);
+    out
+}
+
+/// The user's own extras, and the files that could not be used.
+///
+/// A hand-written file has no CI behind it, so a broken one is reported and skipped rather than
+/// crashing the pane or vanishing without explanation. Having no directory at all is the normal
+/// case and says nothing.
+pub(crate) fn local() -> (Vec<Extra>, Vec<String>) {
+    let (mut good, mut bad) = (Vec::new(), Vec::new());
+    let Ok(dir) = std::fs::read_dir(local_dir()) else {
+        return (good, bad);
+    };
+    let mut paths: Vec<std::path::PathBuf> = dir
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "list"))
+        .collect();
+    paths.sort(); // readdir order is not stable, and a menu that reshuffles is a bad menu
+    for path in paths {
+        let Some(id) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            bad.push(format!("{}: could not be read", path.display()));
+            continue;
+        };
+        let e = parse(id, &body, Source::Local);
+        if e.plugins.is_empty() {
+            bad.push(format!(
+                "{}: lists no plugins — one `owner/repo` per line",
+                path.display()
+            ));
+            continue;
+        }
+        good.push(e);
+    }
+    (good, bad)
+}
+
+/// Is this the id of an extra that ships with the tool?
+pub(crate) fn is_bundled(id: &str) -> bool {
+    REGISTRY.iter().any(|(eid, _)| *eid == id)
+}
+
+/// Look up one extra by id, local first.
+pub(crate) fn find(id: &str) -> Option<Extra> {
+    all().into_iter().find(|e| e.id == id)
 }
 
 /// Parse an extra definition:
 ///   `# category: <name>`  — the grouping label (defaults to "other" if absent)
 ///   `# <text>`            — the one-line description (first comment that is not `category:`)
 ///   `owner/repo`          — one plugin per line; usually one, occasionally a non-overlapping pair
-fn parse(id: &'static str, body: &str) -> Extra {
+fn parse(id: &str, body: &str, source: Source) -> Extra {
     let mut category = String::new();
     let mut description = String::new();
     let mut plugins = Vec::new();
@@ -73,7 +143,7 @@ fn parse(id: &'static str, body: &str) -> Extra {
         }
     }
     Extra {
-        id,
+        id: id.to_string(),
         category: if category.is_empty() {
             "other".to_string()
         } else {
@@ -81,6 +151,7 @@ fn parse(id: &'static str, body: &str) -> Extra {
         },
         description,
         plugins,
+        source,
     }
 }
 
@@ -93,6 +164,7 @@ mod tests {
         let e = parse(
             "x",
             "# category: worktree\n# does a thing\nowner/repo\nowner/two\n",
+            Source::Bundled,
         );
         assert_eq!(e.category, "worktree");
         assert_eq!(e.description, "does a thing");
@@ -104,7 +176,7 @@ mod tests {
 
     #[test]
     fn a_missing_category_defaults_to_other() {
-        let e = parse("x", "# just a description\nowner/repo\n");
+        let e = parse("x", "# just a description\nowner/repo\n", Source::Bundled);
         assert_eq!(e.category, "other");
         assert_eq!(e.description, "just a description");
     }
@@ -112,13 +184,36 @@ mod tests {
     /// The `category:` line must not be consumed as the description.
     #[test]
     fn the_category_line_is_not_mistaken_for_the_description() {
-        let e = parse("x", "# category: nav\n# real description\na/b\n");
+        let e = parse(
+            "x",
+            "# category: nav\n# real description\na/b\n",
+            Source::Bundled,
+        );
         assert_eq!(e.description, "real description");
     }
 
     #[test]
     fn find_returns_none_for_an_unknown_id() {
         assert!(find("definitely-not-an-extra").is_none());
+    }
+
+    /// A hand-written extra reaches the same parser as a bundled one — one format, or the two
+    /// drift and a file that works in one place fails in the other.
+    #[test]
+    fn a_local_extra_is_read_exactly_like_a_bundled_one() {
+        let body = "# category: mine\n# the three things I always install\na/one\nb/two\n";
+        let local = parse("mine", body, Source::Local);
+        let bundled = parse("mine", body, Source::Bundled);
+        assert_eq!(local.category, bundled.category);
+        assert_eq!(local.description, bundled.description);
+        assert_eq!(local.plugins, bundled.plugins);
+        assert_eq!(local.source, Source::Local);
+    }
+
+    #[test]
+    fn bundled_ids_are_recognised() {
+        assert!(is_bundled("worktrunk"));
+        assert!(!is_bundled("mine"));
     }
 
     /// Every embedded seed file must parse into a usable extra — this fails the test step if a

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,7 +741,7 @@ fn cmd_init(force: bool, extra_ids: &[String], from: Option<&str>) -> io::Result
         }
     }
     if !unknown.is_empty() {
-        let known: Vec<&str> = extras::all().iter().map(|e| e.id).collect();
+        let known: Vec<String> = extras::all().iter().map(|e| e.id.clone()).collect();
         eprintln!("unknown extra(s): {}", unknown.join(", "));
         eprintln!("available: {} (see `herdr-lazy extras`)", known.join(", "));
         return Ok(());
@@ -809,9 +809,36 @@ fn cmd_extras() -> io::Result<()> {
     for cat in &categories {
         println!("{}:", cat);
         for e in all.iter().filter(|e| &e.category == cat) {
-            println!("  {:<12} {}", e.id, e.description);
+            // Yours are marked. "Reviewed and shipped with the tool" and "a file I wrote last
+            // Tuesday" are different claims, and the menu should not blur them.
+            let mark = if e.source == extras::Source::Local {
+                " (yours)"
+            } else {
+                ""
+            };
+            println!("  {:<12} {}{}", e.id, e.description, mark);
         }
         println!();
+    }
+
+    // Shadowing is allowed — it is your file — but never silent.
+    let (local, problems) = extras::local();
+    for e in &local {
+        if extras::is_bundled(&e.id) {
+            println!(
+                "note: your `{}` replaces the bundled extra of that name.",
+                e.id
+            );
+        }
+    }
+    for p in &problems {
+        eprintln!("skipped {}", p);
+    }
+    if local.is_empty() && problems.is_empty() {
+        println!(
+            "write your own: drop `<id>.list` in {}",
+            extras::local_dir().display()
+        );
     }
     Ok(())
 }
@@ -2589,7 +2616,8 @@ command = "something.else"
 
     fn extra(plugins: &[&str]) -> extras::Extra {
         extras::Extra {
-            id: "worktrunk",
+            id: "worktrunk".to_string(),
+            source: extras::Source::Bundled,
             category: "worktree".to_string(),
             description: "switch worktrees from a picker".to_string(),
             plugins: plugins.iter().map(|p| p.to_string()).collect(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1500,9 +1500,16 @@ impl App {
         write!(out, "\x1b[H\x1b[2J")?;
         writeln!(
             out,
-            "\x1b[1m extras\x1b[0m  \x1b[2m{} opt-in picks · space ticks, enter adds to your \
+            "\x1b[1m extras\x1b[0m  \x1b[2m{} opt-in picks{} · space ticks, enter adds to your \
              list\x1b[0m\r",
-            p.count()
+            p.count(),
+            if p.items()
+                .any(|(_, it)| it.extra.source == crate::extras::Source::Local)
+            {
+                " · * is yours"
+            } else {
+                ""
+            }
         )?;
         writeln!(out, "\x1b[2m{}\x1b[0m\r", rule)?;
 
@@ -1525,13 +1532,19 @@ impl App {
                         "[ ]"
                     };
                     let mark = if it.listed { "\x1b[32m✔\x1b[0m" } else { " " };
+                    // One of yours reads differently from one that shipped with the tool.
+                    let id = if it.extra.source == crate::extras::Source::Local {
+                        format!("{}*", truncate(&it.extra.id, 11))
+                    } else {
+                        truncate(&it.extra.id, 12)
+                    };
                     writeln!(
                         out,
                         "{} {} {} {:<12} \x1b[2m{}\x1b[0m\r",
                         pointer,
                         tick,
                         mark,
-                        truncate(it.extra.id, 12),
+                        id,
                         truncate(&it.extra.description, width.saturating_sub(24) as usize)
                     )?;
                 }
@@ -2691,10 +2704,10 @@ mod tests {
     fn enter_applies_the_ticks_or_the_cursor() {
         let mut p = ExtrasPicker::new(&[]).expect("extras are registered");
         assert_eq!(p.targets().len(), 1);
-        let under_cursor = p.targets()[0].extra.id;
+        let under_cursor = p.targets()[0].extra.id.clone();
         p.move_cursor(true);
         p.toggle();
-        let ticked: Vec<&str> = p.targets().iter().map(|it| it.extra.id).collect();
+        let ticked: Vec<String> = p.targets().iter().map(|it| it.extra.id.clone()).collect();
         assert_eq!(ticked.len(), 1);
         assert_ne!(ticked[0], under_cursor, "the tick wins, not the cursor");
         // Untick and the cursor is back in charge — this one is still under it.
@@ -2731,7 +2744,7 @@ mod tests {
             app.draw_extras(&mut buf, width, 24).unwrap();
             let out = String::from_utf8(buf).unwrap();
             for e in crate::extras::all() {
-                assert!(out.contains(e.id), "{} missing at width {}", e.id, width);
+                assert!(out.contains(&e.id), "{} missing at width {}", e.id, width);
                 assert!(out.contains(&e.category), "category missing at {}", width);
             }
             assert!(out.contains("[ ]"), "no tick box at width {}", width);


### PR DESCRIPTION
Closes #21.

Extras were curated only: one existed because someone opened a pull request and it cleared the
checklist in CONTRIBUTING. That is the right bar for what ships to everyone, but it made the
only way to name a personal grouping — "the three things I install on every machine" —
convincing this repository to carry it. Absurd for a private bundle, and the answer was never
to lower the bar.

A `.list` file dropped in `extras/` beside your plugin list now joins the menu:

```
# category: mine
# the three things I install on every machine
cloudmanic/herdr-plus
smarzban/herdr-file-viewer
```

Saved as `extras/mine.list`, that is `init --extras mine` and a row marked `*` in the pane.

## The decisions #21 left open

- **Beside the list, not in a config directory.** Same reasoning as `lock_beside`: someone who
  moved their list into a dotfiles repo means to keep what they wrote there too. A hand-written
  extra is content, not state.
- **A directory of files, one extra per file** — matching `extras/` in this repo, and easy to
  share by pasting a file rather than a section of one.
- **Local wins a name collision, and the listing says so.** Least surprising for the person who
  wrote the file; namespacing (`mine:worktrunk`) would put syntax in every command for a rare
  case. Shadowing is allowed because it is your file — but never silently.
- **No `extras new` command.** The format is one you can write by hand; adding a command to
  scaffold two comment lines earns nothing. "Save the current selection as an extra" from the
  pane is the version worth building, and it is a different feature.
- **Categories are not policed.** Inventing one in a personal file is fine.
- **Sharing is out of scope** — `init --from` (#20) shares a whole list; sharing a piece of one
  is a separate question and this does not answer it.

## What keeps it from breaking things

- **One parser.** `include_str!` and a file on disk reach the same `parse`. A test asserts the
  two produce identical results, because two formats that drift is the real failure here.
- **A broken file is named and skipped** — not a panic, not a silent disappearance. There is no
  CI behind a file someone wrote last Tuesday, so `local()` returns the problems alongside the
  extras and `extras` prints them.
- **No directory is the normal case and stays quiet.** The only mention is a line in `extras`
  itself saying where you would put one, which is discoverability in a command you had to ask
  for, not a prompt during ordinary use.
- **Reading order is sorted**, since readdir order is not stable and a menu that reshuffles
  between runs is a bad menu.

## Verified by running it

| | |
|---|---|
| no `extras/` directory | menu unchanged; one line saying where they would go |
| `mine.list` | appears as `mine … (yours)`, works in `init --extras mine` |
| `worktrunk.list` shadowing a bundled id | local one is used, listing notes the replacement |
| an empty file | `skipped …/broken.list: lists no plugins — one owner/repo per line` |

## Tests

131 total, 2 new: local and bundled parse identically, and bundled ids are recognised as such.

`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.

`Extra.id` became a `String` — a local extra's id comes from a filename at runtime and cannot
be `&'static str`.

Not verified: the pane's `*` marker was not looked at on a real terminal.
