### PR TITLE
A default set of things actually in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,15 +400,20 @@ a file pane is a worse default than one.
 
 | plugin | why |
 |---|---|
+| [natori-hrj/herdr-lazy](https://github.com/natori-hrj/herdr-lazy) | this tool, listed so that `u` can update it like anything else |
 | [cloudmanic/herdr-plus](https://github.com/cloudmanic/herdr-plus) | projects and quick actions; the broadest general-purpose add-on |
 | [smarzban/herdr-file-viewer](https://github.com/smarzban/herdr-file-viewer) | git-aware read-only file pane |
 | [persiyanov/herdr-reviewr](https://github.com/persiyanov/herdr-reviewr) | review an agent's diff line by line and send comments back to it |
 | [razajamil/herdr-plugin-workspace-manager](https://github.com/razajamil/herdr-plugin-workspace-manager) | per-workspace tab/pane layouts, applied automatically |
-| [natori-hrj/herdr-triage](https://github.com/natori-hrj/herdr-triage) | ranks agents by who needs you most |
 
-The last one is by this project's author. It is here because running several agents at once
-creates a problem the ecosystem does not otherwise address — knowing which one to look at —
-not because of who wrote it. If that is not your problem, remove it.
+The first entry is this tool. `update` and the pane's `u` only act on what your list names, so
+leaving it out made herdr-lazy the one plugin herdr-lazy could not update. Removing it from the
+list does not endanger it: `--prune` refuses to uninstall it by identity, not by membership.
+
+There is one more criterion, and it outranks the rest: somebody has to actually use these.
+Popularity is evidence of that, not a substitute — an earlier version of this set kept a plugin
+on three stars that its own author never ran. The author's own plugins clear that bar or leave,
+exactly as anyone else's do.
 
 A third criterion showed up during testing: it has to actually install. herdr runs plugin
 builds with a minimal PATH that excludes `~/.cargo/bin`, so a plugin whose build is a bare

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,12 @@ use std::process::Command;
 /// the gaps nothing else covers. Overlapping plugins are deliberately excluded rather than
 /// stacked — two plugins that both open a file pane is a worse default than one.
 ///
+/// And one that outranks both: somebody has to actually use it. Popularity is evidence of
+/// that, not a substitute for it — `herdr-triage` was kept here on three stars after
+/// `herdr-green` and `herdr-standup` were cut for being unused, which was the same mistake
+/// with a better-looking number attached. It is gone for the same reason they were. The
+/// author's own plugins clear this bar or leave, exactly as anyone else's do.
+///
 /// A third criterion, learned the hard way: it has to actually install. herdr runs plugin
 /// builds with a minimal PATH that excludes `~/.cargo/bin`, so a plugin whose build is a bare
 /// `cargo build --release` fails on machines where Rust is installed and works fine in the
@@ -58,13 +64,20 @@ use std::process::Command;
 /// Edit freely — `herdr-lazy init` writes these into your bundle file, and nothing here is
 /// load-bearing.
 const DEFAULT_BUNDLE: &[&str] = &[
+    // Listed so the tool can be updated by the tool. `u` in the pane, and `update` on the
+    // command line, only act on entries in the list — leaving herdr-lazy out meant the one
+    // plugin you could not update with herdr-lazy was herdr-lazy. `--prune` never removes it
+    // either way; that is handled by identity, not by membership.
+    //
+    // Updating it replaces the binary of the running process. That is fine on Unix, where the
+    // open inode outlives the rename, and it has been done on Windows too (see #2) — but it is
+    // the reason this entry is worth a comment rather than being obvious.
+    "natori-hrj/herdr-lazy",
     // Proven in the ecosystem, and verified to install cleanly.
     "cloudmanic/herdr-plus",                    // projects + quick actions
     "smarzban/herdr-file-viewer",               // git-aware read-only file pane
     "persiyanov/herdr-reviewr",                 // comment on an agent's diff, send it back
     "razajamil/herdr-plugin-workspace-manager", // per-workspace tab/pane layouts; no build step
-    // Gap nothing else covers: keeping a human oriented across several running agents.
-    "natori-hrj/herdr-triage", // which agent needs you most
 ];
 
 fn herdr_bin() -> String {


### PR DESCRIPTION
Two changes to `DEFAULT_BUNDLE`, one correcting a judgement and one closing a gap.

## `herdr-triage` is out

`herdr-green` and `herdr-standup` were cut from this set for a stated reason: their author had
never used them. `herdr-triage` was kept in the same conversation because it had three stars.

That was the same mistake with a better-looking number attached. Popularity is evidence that
somebody uses a plugin, not a substitute for it — and here the evidence was available directly
and said no. The set was shipping the author's own plugin, which the author does not run, to
every new user. CONTRIBUTING says the author's plugins clear the same bar as anyone else's;
this is that bar being applied.

The gap it filled — keeping a human oriented across several running agents — is still a real
gap. It is a good candidate for an extra, or for someone else's pull request.

## `herdr-lazy` is in

`update`, and `u` in the pane, only act on entries the list names. Leaving herdr-lazy out of
the list it writes made herdr-lazy the one plugin herdr-lazy could not update: you had to drop
to `herdr plugin install` by hand, in a tool whose entire argument is that the list is how you
manage things.

Being absent from the list never endangered it — `--prune` refuses to uninstall it by
identity, not by membership, and the pane shows it as `◆ this is herdr-lazy`. So this is about
the update path, not about safety.

Worth knowing, and now commented at the entry: updating it replaces the binary of the running
process. Fine on Unix, where the open inode outlives the rename, and done on Windows too (#2).

## Result

```
natori-hrj/herdr-lazy
cloudmanic/herdr-plus
smarzban/herdr-file-viewer
persiyanov/herdr-reviewr
razajamil/herdr-plugin-workspace-manager
```

Five entries, four of them other people's, all of them in use by the person shipping the set.

The README's paragraph defending the author's plugin is replaced by the criterion that made it
unnecessary. The reasoning behind removing triage is recorded in the code comment as well, so
the next person to propose a popular-but-unused plugin meets the argument rather than only the
outcome.

133 tests pass; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
`init` output verified by hand.
