### PR TITLE
A real list to start from

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,16 @@ herdr-lazy init --from owner/repo        # their plugins.list becomes yours
 herdr-lazy init --from owner/repo@v1     # at a ref, if you would rather it not move
 ```
 
+A real one, if you want somewhere to start:
+
+```sh
+herdr-lazy init --from natori-hrj/herdr-config
+```
+
+That is this project author's own list — the five plugins actually in use, which is also why
+they are the ones in the default set. Publishing yours is a repository with a `plugins.list` at
+the root and nothing else required.
+
 It reads `plugins.list` from the root of that repository and writes it as your list, comments
 and all. After that it is your file: there is no upstream, no link back, and nothing to update
 from. A fork, not a subscription — the whole point is that you can now disagree with it.


### PR DESCRIPTION
`init --from` shipped in #31 with no published list to point at, so the README could only show `owner/repo`. There is one now: [natori-hrj/herdr-config](https://github.com/natori-hrj/herdr-config), the five plugins this project's author actually runs — the same five that are in the default set, which is the point.

Also closes the honest gap in #31: that PR said the live success path had never been exercised, because nothing published a `plugins.list` at the time. It has now been run against GitHub, in both forms:

```
adopted 5 plugin(s) from natori-hrj/herdr-config -> …/plugins.list
adopted 5 plugin(s) from natori-hrj/herdr-config@main -> …/plugins.list
```

Comments survive the trip, the provenance line lands at the top, and nothing is installed.

Documentation only.