### PR TITLE
doctor says when an entry no longer resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ herdr-lazy update smarzban/herdr-file-viewer
 | `remove <owner/repo>` | remove an entry from the bundle |
 | `lock` | write the lockfile from the current bundle |
 | `auto-sync [on\|off]` | install missing plugins automatically when herdr starts |
+| `doctor` | check that every entry in your list still resolves |
 | `probe [--raw]` | check the herdr bridge and show the resolved paths; `--raw` adds the full payloads |
 
 ### Already using herdr?
@@ -333,6 +334,30 @@ scp other-machine:~/.config/herdr/plugins/config/herdr-lazy/plugins.lock .
 cp plugins.lock "$(herdr plugin config-dir herdr-lazy)/"
 herdr-lazy restore
 ```
+
+## When an entry stops resolving
+
+```sh
+herdr-lazy doctor
+```
+
+A repository that no longer exists is the one way a list quietly stops being reproducible: copy
+it to a new machine, `sync`, and the install fails. `doctor` asks whether each entry still
+resolves and reports the ones that do not.
+
+```
+9 plugin(s) · 8 resolve · 1 not found
+  someone/herdr-thing — repository not found
+```
+
+It reports facts and does nothing else — no entry is removed and nothing is uninstalled. A
+plugin you already have keeps working, and the entry is worth keeping while you decide what
+replaces it.
+
+"Not found" is what was observed, not a conclusion: a repository made private looks exactly like
+a deleted one from outside. A renamed or transferred one redirects and is not reported, because
+`herdr plugin install` follows the same redirect. When the network is unavailable it says so,
+rather than reporting everything as gone.
 
 ## Keeping in sync automatically
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -61,6 +61,59 @@ pub(crate) fn raw_file(owner_repo: &str, reference: Option<&str>, path: &str) ->
     ))
 }
 
+/// Whether a repository still answers.
+///
+/// The plain repository URL, not the API: unauthenticated API calls are capped at 60 an hour,
+/// which a list of any size would eat, and only the status code is wanted here. A renamed or
+/// transferred repository redirects and so resolves — which is right, since `plugin install`
+/// follows the same redirect.
+///
+/// `None` means the question could not be asked (no network, no curl or wget), which is not the
+/// same as an answer and must never be reported as one.
+pub(crate) fn repo_exists(owner_repo: &str) -> Option<bool> {
+    let base = std::env::var("HERDR_LAZY_REPO_BASE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "https://github.com".to_string());
+    let url = format!("{}/{}", base, owner_repo);
+
+    // `-o /dev/null -w %{http_code}` rather than `-f`, so a 404 is an answer and a dead network
+    // is a failure — telling the two apart is the whole point.
+    if let Ok(out) = Command::new("curl")
+        .args([
+            "-sIL",
+            "--max-time",
+            "15",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            "-H",
+            "User-Agent: herdr-lazy",
+            &url,
+        ])
+        .output()
+    {
+        if out.status.success() {
+            let code = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if let Ok(n) = code.parse::<u16>() {
+                if n > 0 {
+                    return Some(n < 400);
+                }
+            }
+        }
+    }
+    // wget exits 8 on a server error response, which is an answer of "not found".
+    match Command::new("wget")
+        .args(["-q", "--spider", "--timeout=15", &url])
+        .status()
+    {
+        Ok(s) if s.success() => Some(true),
+        Ok(s) if s.code() == Some(8) => Some(false),
+        _ => None,
+    }
+}
+
 /// Shell out to curl/wget — std has no TLS, the same reason the install script and the
 /// marketplace fetch do.
 fn fetch(url: &str) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -935,6 +935,70 @@ fn cmd_extras() -> io::Result<()> {
     Ok(())
 }
 
+/// The repository a list entry lives in. `owner/repo/plugins/wm` is hosted by `owner/repo`,
+/// and asking about the subdirectory would report a perfectly healthy plugin as missing.
+fn repo_root(repo: &str) -> String {
+    repo.split('/').take(2).collect::<Vec<_>>().join("/")
+}
+
+/// `doctor` — check that every entry in the list still resolves.
+///
+/// A repository that no longer exists is the one thing about a decaying herd that needs no
+/// judgement: copy the list to a new machine, `sync`, and the install fails. The list has
+/// stopped being reproducible, and nothing else says so until the day it matters.
+///
+/// Facts only. Nothing is removed from the list and nothing is uninstalled — a plugin already
+/// installed keeps working, and the entry may be worth keeping while a replacement is chosen.
+fn cmd_doctor() -> io::Result<()> {
+    let desired = desired_plugins();
+    if desired.is_empty() {
+        println!(
+            "no plugin list at {} — nothing to check.",
+            bundle_path().display()
+        );
+        return Ok(());
+    }
+
+    let mut gone = Vec::new();
+    let mut unknown = Vec::new();
+    let mut ok = 0;
+    for line in &desired {
+        let repo = Spec::parse(line).repo;
+        match github::repo_exists(&repo_root(&repo)) {
+            Some(true) => ok += 1,
+            // "not found", not "deleted": a repository made private looks exactly the same from
+            // outside, and reporting a conclusion nobody verified would be worse than useless.
+            Some(false) => gone.push(repo),
+            None => unknown.push(repo),
+        }
+    }
+
+    println!(
+        "{} plugin(s) · {} resolve · {} not found{}",
+        desired.len(),
+        ok,
+        gone.len(),
+        if unknown.is_empty() {
+            String::new()
+        } else {
+            format!(" · {} could not be checked", unknown.len())
+        }
+    );
+    for r in &gone {
+        println!("  {} — repository not found", r);
+    }
+    for r in &unknown {
+        println!("  {} — could not be checked (no network?)", r);
+    }
+    if !gone.is_empty() {
+        println!(
+            "\nAn entry that cannot be fetched will fail on a machine that does not have it \
+             installed.\nIt may have been renamed and left no redirect, or made private."
+        );
+    }
+    Ok(())
+}
+
 fn cmd_list() -> io::Result<()> {
     let desired = desired_plugins();
     if desired.is_empty() {
@@ -2207,6 +2271,7 @@ fn print_help() {
     println!("  init [--force] [--extras <id,…>] [--from <owner/repo[@ref]>] [--dry-run]");
     println!("                    write the default bundle, or adopt someone else's list");
     println!("  extras            list the opt-in extras you can pass to `init --extras`");
+    println!("  doctor            check that every entry in your list still resolves");
     println!("  list              show desired plugins");
     println!("  install [<repo>…] install what is missing, restore drifted pins");
     println!("  sync [--prune]    the same, plus --prune to remove what is not listed");
@@ -2235,6 +2300,7 @@ fn main() {
             rest.contains(&"--dry-run"),
         ),
         "extras" => cmd_extras(),
+        "doctor" => cmd_doctor(),
         "list" => cmd_list(),
         // `install` is what people look for; `sync` is what the operation is. Both, rather
         // than choosing and leaving the other as a dead end.
@@ -3171,6 +3237,28 @@ command = "something.else"
         ] {
             assert_eq!(build_check(repo), want, "{}", repo);
         }
+    }
+
+    /// A subdirectory entry is hosted by its parent repository. Asking about the subdirectory
+    /// would report a healthy plugin as missing, which is the one thing `doctor` must not do.
+    #[test]
+    fn doctor_asks_about_the_repository_an_entry_lives_in() {
+        assert_eq!(repo_root("owner/repo"), "owner/repo");
+        assert_eq!(repo_root("owner/repo/plugins/wm"), "owner/repo");
+        assert_eq!(repo_root("owner"), "owner");
+    }
+
+    /// A dead network must never look like a deleted repository. Run manually: it needs one.
+    #[test]
+    #[ignore]
+    fn live_repo_existence_tells_the_three_cases_apart() {
+        assert_eq!(github::repo_exists("cloudmanic/herdr-plus"), Some(true));
+        assert_eq!(
+            github::repo_exists("natori-hrj/definitely-not-a-real-repo-xyz"),
+            Some(false)
+        );
+        // A transferred repository redirects, and `plugin install` follows the same redirect.
+        assert_eq!(github::repo_exists("ogulcancelik/herdr"), Some(true));
     }
 
     /// The floor herdr enforces and the floor the README promises have to be the same number.


### PR DESCRIPTION
Closes #41.

A repository that no longer exists is the one way a list quietly stops being reproducible: copy
it to a new machine, `sync`, and the install fails. Nothing said so until the day it mattered.

```sh
$ herdr-lazy doctor
9 plugin(s) · 8 resolve · 1 not found
  someone/herdr-thing — repository not found
```

Facts only. No entry is removed and nothing is uninstalled — a plugin already installed keeps
working, and the entry is worth keeping while a replacement is chosen.

## The part that had to be right

A dead network must never look like a deleted repository. Reporting "all nine of your plugins
are gone" because the wifi dropped would be worse than reporting nothing at all.

So the check uses `curl -w %{http_code}` rather than `-f`: a 404 is an *answer*, a connection
failure is *not an answer*, and the two are reported differently.

```
3 plugin(s) · 0 resolve · 0 not found · 3 could not be checked
  cloudmanic/herdr-plus — could not be checked (no network?)
```

`repo_exists` returns `Option<bool>` for the same reason — `None` is "could not ask", which is
not a value `doctor` is allowed to turn into a verdict.

The wording is observational for a related reason: a repository made private is indistinguishable
from a deleted one out here, so the output says "not found", never "deleted".

## Not the API

Unauthenticated GitHub API calls are capped at 60 an hour, which a list of any size would eat.
Only a status code is wanted, and the plain repository URL gives one without that cap.

## Exercised against real repositories

| case | result |
|---|---|
| the author's real 9-entry list | `9 resolve · 0 not found` |
| a repository that does not exist | reported, by name |
| network pointed at a dead host | `could not be checked`, **not** "not found" |
| `ogulcancelik/herdr` — transferred to `herdrdev` | resolves through the redirect |
| `owner/repo/plugins/wm` | asks about `owner/repo` |

The redirect case is the herdr organisation migration from v0.8.0, which makes it a real test
rather than a contrived one — and following it is correct, since `herdr plugin install` follows
the same redirect.

## Split from #38

#38 asked how a herd goes stale. Most of that needs a judgement — how many months of quiet is
too many — and a judgement is what a tool should leave to a person. This half needs none, so it
went first. The rest stays in #38.

## Tests

144 total, 1 new unit test (a subdirectory entry is checked against its parent repository, or a
healthy plugin gets reported as missing), plus an `#[ignore]`d live test that pins the three
outcomes apart. `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
clean.
